### PR TITLE
XSD schema fixed by parser/examples

### DIFF
--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -90,7 +90,7 @@
              </xs:documentation>
          </xs:annotation>
          <xs:sequence>
-             <xs:element name="provider-loader">
+             <xs:element name="provider-loader" maxOccurs="unbounded">
                  <xs:annotation>
                      <xs:documentation>
                          An individual provider loader definitions.
@@ -129,7 +129,7 @@
                                          </xs:annotation>
                                          <xs:complexType>
                                              <xs:sequence>
-                                                 <xs:element name="property" type="propertyType" />
+                                                 <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
                                              </xs:sequence>
                                          </xs:complexType>
                                      </xs:element>
@@ -235,7 +235,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="post-realm-rewriter" type="xs:string">
+        <xs:attribute name="post-realm-name-rewriter" type="xs:string">
             <xs:annotation>
                 <xs:documentation>
                     Reference to the NameRewriter to be applied after the realm is selected.
@@ -768,7 +768,7 @@
 
     <xs:complexType name="ldapAttributeMappingType">
         <xs:sequence>
-            <xs:element name="attribute" type="ldapAttributeType" minOccurs="0" />
+            <xs:element name="attribute" type="ldapAttributeType" minOccurs="0" maxOccurs="unbounded" />
         </xs:sequence>
     </xs:complexType>
 
@@ -885,7 +885,7 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="replacment" type="xs:string" use="required">
+                <xs:attribute name="replacement" type="xs:string" use="required">
                     <xs:annotation>
                         <xs:documentation>
                             The replacement string for this NameRewriter.
@@ -1222,7 +1222,7 @@
         <xs:complexContent>
             <xs:extension base="realmMapperType">
                 <xs:sequence>
-                    <xs:element name="realm-mapping">
+                    <xs:element name="realm-mapping" maxOccurs="unbounded">
                         <xs:complexType>
                             <xs:attribute name="from" type="xs:string" use="required">
                                 <xs:annotation>
@@ -1453,7 +1453,7 @@
         </xs:annotation>
         <xs:complexContent>
             <xs:extension base="roleMapperType">
-                <xs:attribute name="operation" type="logicalOperationType" use="required">
+                <xs:attribute name="logical-operation" type="logicalOperationType" use="required">
                     <xs:annotation>
                         <xs:documentation>
                             The logicial operation to perform using the two referenced RoleMappers.
@@ -1639,7 +1639,7 @@
              <xs:element name="aggregate-http-server-factory" type="aggregateHttpServerFactoryType" minOccurs="0" />
              <xs:element name="configurable-http-server-factory" type="configurableHttpServerFactoryType" minOccurs="0" />
              <xs:element name="provider-http-server-factory" type="providerHttpServerFactoryType" minOccurs="0" />
-             <xs:element name="service-loader-htt-server-factory" type="serviceLoaderHttpServerFactoryType" minOccurs="0" />
+             <xs:element name="service-loader-http-server-factory" type="serviceLoaderHttpServerFactoryType" minOccurs="0" />
          </xs:choice>
      </xs:complexType>
 


### PR DESCRIPTION
XSD schema fixed to be conform with examples and tests.
(To ensure green validation result of examples reorder of tags in examples or #140 required.)

* maxOccures of element in `<properties>` and similar should be unbounded
* mispelled name (htt vs http)
* probably old names of attributes (post-realm-rewriter vs post-realm-**name**-rewriter, operation vs **logical-**operation)