### PR TITLE
[ELY-558] Add the ability for domains to make use of a shared executor for handling authentication timeout tasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <version.org.jboss.logging.tools>2.0.1.Final</version.org.jboss.logging.tools>
         <version.org.jboss.msc.jboss-msc>1.2.6.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.staxmapper>1.2.0.Final</version.org.jboss.staxmapper>
+        <version.org.jboss.threads>2.2.1.Final</version.org.jboss.threads>
         <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.1.0.Final</version.org.wildfly.common>
         <version.com.puppycrawl.tools.checkstyle>6.0</version.com.puppycrawl.tools.checkstyle>
@@ -283,6 +284,19 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-server</artifactId>
+            <version>${version.wildfly.core}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron</artifactId>
             <version>${version.elytron}</version>
@@ -313,6 +327,13 @@
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
             <version>${version.org.jboss.msc.jboss-msc}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.threads</groupId>
+            <artifactId>jboss-threads</artifactId>
+            <version>${version.org.jboss.threads}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
@@ -33,6 +33,7 @@ import static org.wildfly.extension.elytron.ElytronExtension.asStringIfDefined;
 import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.ROOT_LOGGER;
 
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectListAttributeDefinition;
@@ -260,6 +261,7 @@ class DomainDefinition extends SimpleResourceDefinition {
         }
 
         commonDependencies(domainBuilder);
+        domainBuilder.addDependency(CoreService.CORE_SCHEDULED_EXECUTOR_SERVICE_NAME, ScheduledExecutorService.class, domain.getScheduledExecutorServiceInjector());
         return domainBuilder.install();
     }
 

--- a/src/main/java/org/wildfly/extension/elytron/DomainService.java
+++ b/src/main/java/org/wildfly/extension/elytron/DomainService.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import org.jboss.as.controller.OperationFailedException;
@@ -76,6 +77,7 @@ class DomainService implements Service<SecurityDomain> {
     private final InjectedValue<RealmMapper> realmMapperInjector = new InjectedValue<>();
     private final InjectedValue<PermissionMapper> permissionMapperInjector = new InjectedValue<>();
     private final HashSet<SecurityDomain> trustedSecurityDomains = new HashSet<>();
+    private final InjectedValue<ScheduledExecutorService> scheduledExecutorServiceInjector = new InjectedValue<>();
 
     DomainService(final String name, final String defaultRealm, final List<String> trustedSecurityDomainsList) {
         this.name = name;
@@ -153,6 +155,10 @@ class DomainService implements Service<SecurityDomain> {
         return createRoleMapperInjector(name);
     }
 
+    Injector<ScheduledExecutorService> getScheduledExecutorServiceInjector() {
+        return scheduledExecutorServiceInjector;
+    }
+
     @Override
     public void start(StartContext context) throws StartException {
         SecurityDomain.Builder builder = SecurityDomain.builder();
@@ -200,6 +206,9 @@ class DomainService implements Service<SecurityDomain> {
         }
 
         builder.setTrustedSecurityDomainPredicate(trustedSecurityDomains::contains);
+
+        ScheduledExecutorService scheduledExecutorService = scheduledExecutorServiceInjector.getValue();
+        builder.setScheduledExecutorService(scheduledExecutorService);
 
         securityDomain = builder.build();
 

--- a/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -78,6 +78,7 @@ interface ElytronDescriptionConstants {
     String CONSTANT_PRINCIPAL_DECODER = "constant-principal-decoder";
     String CONSTANT_ROLE_MAPPER = "constant-role-mapper";
     String CORE_SERVICE = "core-service";
+    String CORE_SCHEDULED_EXECUTOR_SERVICE = "core-scheduled-executor-service";
     String CREATION_DATE = "creation-date";
     String CREATION_TIME = "creation-time";
     String CREDENTIAL = "credential";

--- a/src/main/resources/module/main/module.xml
+++ b/src/main/resources/module/main/module.xml
@@ -37,6 +37,7 @@
         <module name="org.jboss.msc"/>
         <module name="org.jboss.vfs"/>
         <module name="org.jboss.logging"/>
+        <module name="org.jboss.threads"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron"/>
     </dependencies>


### PR DESCRIPTION
Depends on https://github.com/wildfly-security/wildfly-elytron/pull/458