### PR TITLE
[ELY-462] DirContext definition outside of realms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.elytron>1.1.0.Beta7</version.elytron>
+        <version.elytron>1.1.0.Beta8-SNAPSHOT</version.elytron>
 
         <version.wildfly.core>3.0.0.Alpha3</version.wildfly.core>
 
@@ -46,7 +46,7 @@
         <version.org.jboss.msc.jboss-msc>1.2.6.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.staxmapper>1.2.0.Final</version.org.jboss.staxmapper>
         <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.common>1.1.0.Final</version.org.wildfly.common>
+        <version.org.wildfly.common>1.2.0.Beta1</version.org.wildfly.common>
         <version.com.puppycrawl.tools.checkstyle>6.0</version.com.puppycrawl.tools.checkstyle>
         <version.junit>4.12</version.junit>
         <version.jmockit>1.10</version.jmockit>

--- a/src/main/java/org/wildfly/extension/elytron/Capabilities.java
+++ b/src/main/java/org/wildfly/extension/elytron/Capabilities.java
@@ -27,6 +27,7 @@ import javax.net.ssl.TrustManager;
 import javax.security.sasl.SaslServerFactory;
 
 import org.jboss.as.controller.capability.RuntimeCapability;
+import org.wildfly.common.function.ExceptionSupplier;
 import org.wildfly.security.SecurityFactory;
 import org.wildfly.security.auth.server.HttpAuthenticationFactory;
 import org.wildfly.security.auth.server.ModifiableSecurityRealm;
@@ -169,6 +170,12 @@ class Capabilities {
 
     static final RuntimeCapability<Void> TRUST_MANAGERS_RUNTIME_CAPABILITY =  RuntimeCapability
             .Builder.of(TRUST_MANAGERS_CAPABILITY, true, TrustManager[].class)
+            .build();
+
+    static final String DIR_CONTEXT_CAPABILITY = CAPABILITY_BASE + "dir-context";
+
+    static final RuntimeCapability<Void> DIR_CONTEXT_RUNTIME_CAPABILITY = RuntimeCapability
+            .Builder.of(DIR_CONTEXT_CAPABILITY, true, ExceptionSupplier.class) // ExceptionSupplier<DirContext, Exception>
             .build();
 
     /**

--- a/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
@@ -1,0 +1,149 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.elytron;
+
+import static org.wildfly.extension.elytron.Capabilities.DIR_CONTEXT_RUNTIME_CAPABILITY;
+import static org.wildfly.security.auth.realm.ldap.DirContextFactory.ReferralMode;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.wildfly.common.function.ExceptionSupplier;
+import org.wildfly.security.auth.realm.ldap.DelegatingLdapContext;
+import org.wildfly.security.auth.realm.ldap.DirContextFactory;
+import org.wildfly.security.auth.realm.ldap.SimpleDirContextFactoryBuilder;
+
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+import java.util.Properties;
+
+/**
+ * A {@link ResourceDefinition} for a {@link javax.naming.directory.DirContext}.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public class DirContextDefinition extends SimpleResourceDefinition {
+
+    public static final String CONNECTION_POOLING_PROPERTY = "com.sun.jndi.ldap.connect.pool";
+
+    static final SimpleAttributeDefinition URL = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.URL, ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+
+    static final SimpleAttributeDefinition AUTHENTICATION_LEVEL = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.AUTHENTICATION_LEVEL, ModelType.STRING, true)
+            .setDefaultValue(new ModelNode("simple"))
+            .setAllowedValues("none", "simple", "strong")
+            .setAllowExpression(true)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+
+    static final SimpleAttributeDefinition PRINCIPAL = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PRINCIPAL, ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+
+    static final SimpleAttributeDefinition CREDENTIAL = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CREDENTIAL, ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+
+    static final SimpleAttributeDefinition ENABLE_CONNECTION_POOLING = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ENABLE_CONNECTION_POOLING, ModelType.BOOLEAN, true)
+            .setDefaultValue(new ModelNode(false))
+            .setAllowExpression(true)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+
+    static final SimpleAttributeDefinition REFERRAL_MODE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.REFERRAL_MODE, ModelType.STRING, true)
+            .setDefaultValue(new ModelNode(ReferralMode.IGNORE.name()))
+            .setAllowedValues(ReferralMode.FOLLOW.name(), ReferralMode.IGNORE.name(), ReferralMode.THROW.name())
+            .setAllowExpression(true)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+
+    static final SimpleAttributeDefinition[] ATTRIBUTES = new SimpleAttributeDefinition[] {URL, AUTHENTICATION_LEVEL, PRINCIPAL, CREDENTIAL, ENABLE_CONNECTION_POOLING, REFERRAL_MODE};
+
+    DirContextDefinition() {
+        super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(ElytronDescriptionConstants.DIR_CONTEXT), ElytronExtension.getResourceDescriptionResolver(ElytronDescriptionConstants.DIR_CONTEXT))
+                .setAddHandler(ADD)
+                .setRemoveHandler(REMOVE)
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setCapabilities(DIR_CONTEXT_RUNTIME_CAPABILITY));
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        for (AttributeDefinition current : ATTRIBUTES) {
+            resourceRegistration.registerReadOnlyAttribute(current, null);
+        }
+    }
+
+    private static TrivialService.ValueSupplier<ExceptionSupplier<DirContext, NamingException>> obtainDirContextSupplier(final OperationContext context, final ModelNode model) throws OperationFailedException {
+
+        Properties connectionProperties = new Properties();
+        ModelNode enableConnectionPoolingNode = ENABLE_CONNECTION_POOLING.resolveModelAttribute(context, model);
+        connectionProperties.put(CONNECTION_POOLING_PROPERTY, enableConnectionPoolingNode.asBoolean());
+        ReferralMode referralMode = ReferralMode.valueOf(REFERRAL_MODE.resolveModelAttribute(context, model).asString());
+
+        DirContextFactory dirContextFactory = SimpleDirContextFactoryBuilder.builder()
+                .setProviderUrl(URL.resolveModelAttribute(context, model).asString())
+                .setSecurityAuthentication(AUTHENTICATION_LEVEL.resolveModelAttribute(context, model).asString())
+                .setSecurityPrincipal(PRINCIPAL.resolveModelAttribute(context, model).asString())
+                .setSecurityCredential(CREDENTIAL.resolveModelAttribute(context, model).asString())
+                .setConnectionProperties(connectionProperties)
+                .build();
+
+        return () -> () -> new DelegatingLdapContext(dirContextFactory, referralMode);
+    }
+
+    private static final AbstractAddStepHandler ADD = new AbstractAddStepHandler(DIR_CONTEXT_RUNTIME_CAPABILITY, ATTRIBUTES) {
+        protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+
+            RuntimeCapability<Void> runtimeCapability = DIR_CONTEXT_RUNTIME_CAPABILITY.fromBaseCapability(context.getCurrentAddressValue());
+            ServiceName serviceName = runtimeCapability.getCapabilityServiceName(ExceptionSupplier.class);
+
+            TrivialService<ExceptionSupplier<DirContext, NamingException>> service = new TrivialService<>(obtainDirContextSupplier(context, model));
+            ServiceBuilder<ExceptionSupplier<DirContext, NamingException>> serviceBuilder = context.getServiceTarget().addService(serviceName, service);
+
+            serviceBuilder
+                    .setInitialMode(ServiceController.Mode.ACTIVE)
+                    .install();
+        }
+    };
+
+    private static final OperationStepHandler REMOVE = new TrivialCapabilityServiceRemoveHandler(ADD, DIR_CONTEXT_RUNTIME_CAPABILITY);
+
+}

--- a/src/main/java/org/wildfly/extension/elytron/DirContextParser.java
+++ b/src/main/java/org/wildfly/extension/elytron/DirContextParser.java
@@ -1,0 +1,145 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.elytron;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+import javax.xml.stream.XMLStreamException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.parsing.ParseUtils.isNoNamespaceAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoAttributes;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.NAME;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.URL;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.AUTHENTICATION_LEVEL;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.PRINCIPAL;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CREDENTIAL;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.ENABLE_CONNECTION_POOLING;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.REFERRAL_MODE;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.DIR_CONTEXT;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.DIR_CONTEXTS;
+import static org.wildfly.extension.elytron.ElytronSubsystemParser.verifyNamespace;
+
+
+/**
+ * A parser for the DirContext definition.
+ *
+ * <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public class DirContextParser {
+
+    void readDirContexts(ModelNode parentAddress, XMLExtendedStreamReader reader, List<ModelNode> operations) throws XMLStreamException {
+        requireNoAttributes(reader);
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            verifyNamespace(reader);
+            String localName = reader.getLocalName();
+            if (DIR_CONTEXT.equals(localName)) {
+                readDirContext(parentAddress, reader, operations);
+            } else {
+                throw unexpectedElement(reader);
+            }
+        }
+    }
+
+    void readDirContext(ModelNode parentAddress, XMLExtendedStreamReader reader, List<ModelNode> operations) throws XMLStreamException {
+        ModelNode addDirContext = new ModelNode();
+        addDirContext.get(OP).set(ADD);
+
+        Set<String> requiredXmlAttributes = new HashSet<>(Arrays.asList(new String[]{ NAME, URL }));
+
+        String name = null;
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            final String value = reader.getAttributeValue(i);
+            if (!isNoNamespaceAttribute(reader, i)) {
+                throw unexpectedAttribute(reader, i);
+            } else {
+                String attribute = reader.getAttributeLocalName(i);
+                requiredXmlAttributes.remove(attribute);
+                switch (attribute) {
+                    case NAME:
+                        name = value;
+                        break;
+                    case URL:
+                        DirContextDefinition.URL.parseAndSetParameter(value, addDirContext, reader);
+                        break;
+                    case AUTHENTICATION_LEVEL:
+                        DirContextDefinition.AUTHENTICATION_LEVEL.parseAndSetParameter(value, addDirContext, reader);
+                        break;
+                    case PRINCIPAL:
+                        DirContextDefinition.PRINCIPAL.parseAndSetParameter(value, addDirContext, reader);
+                        break;
+                    case CREDENTIAL:
+                        DirContextDefinition.CREDENTIAL.parseAndSetParameter(value, addDirContext, reader);
+                        break;
+                    case ENABLE_CONNECTION_POOLING:
+                        DirContextDefinition.ENABLE_CONNECTION_POOLING.parseAndSetParameter(value, addDirContext, reader);
+                        break;
+                    case REFERRAL_MODE:
+                        DirContextDefinition.REFERRAL_MODE.parseAndSetParameter(value, addDirContext, reader);
+                        break;
+                    default:
+                        throw unexpectedAttribute(reader, i);
+                }
+            }
+        }
+
+        if (requiredXmlAttributes.isEmpty() == false) {
+            throw missingRequired(reader, requiredXmlAttributes);
+        }
+        requireNoContent(reader);
+
+        addDirContext.get(OP_ADDR).set(parentAddress).add(DIR_CONTEXT, name);
+        operations.add(addDirContext);
+    }
+
+    void writeDirContexts(ModelNode subsystem, XMLExtendedStreamWriter writer) throws XMLStreamException {
+        if (subsystem.hasDefined(DIR_CONTEXT)) {
+            writer.writeStartElement(DIR_CONTEXTS);
+            ModelNode dirContexts = subsystem.require(DIR_CONTEXT);
+            for (String name : dirContexts.keys()) {
+                ModelNode dirContext = dirContexts.require(name);
+                writer.writeStartElement(DIR_CONTEXT);
+                writer.writeAttribute(NAME, name);
+                DirContextDefinition.URL.marshallAsAttribute(dirContext, writer);
+                DirContextDefinition.AUTHENTICATION_LEVEL.marshallAsAttribute(dirContext, writer);
+                DirContextDefinition.PRINCIPAL.marshallAsAttribute(dirContext, writer);
+                DirContextDefinition.CREDENTIAL.marshallAsAttribute(dirContext, writer);
+                DirContextDefinition.ENABLE_CONNECTION_POOLING.marshallAsAttribute(dirContext, writer);
+                DirContextDefinition.REFERRAL_MODE.marshallAsAttribute(dirContext, writer);
+                writer.writeEndElement();
+            }
+            writer.writeEndElement();
+        }
+    }
+
+}

--- a/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -88,6 +88,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
 
         // Domain
         resourceRegistration.registerSubModel(new DomainDefinition());
+
         // Security Realms
         resourceRegistration.registerSubModel(new AggregateRealmDefinition());
         resourceRegistration.registerSubModel(new CustomComponentDefinition<SecurityRealm>(SecurityRealm.class, ElytronDescriptionConstants.CUSTOM_REALM, SECURITY_REALM_RUNTIME_CAPABILITY));
@@ -160,6 +161,9 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(SSLDefinitions.getKeyManagerDefinition());
         resourceRegistration.registerSubModel(SSLDefinitions.getTrustManagerDefinition());
         resourceRegistration.registerSubModel(SSLDefinitions.getServerSSLContextBuilder());
+
+        // Dir-Context
+        resourceRegistration.registerSubModel(new DirContextDefinition());
     }
 
     static <T> ServiceBuilder<T>  commonDependencies(ServiceBuilder<T> serviceBuilder) {

--- a/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -102,6 +102,7 @@ interface ElytronDescriptionConstants {
     String DELEGATE_REALM_MAPPER = "delegate-realm-mapper";
     String DIGEST = "digest";
     String DIR_CONTEXT = "dir-context";
+    String DIR_CONTEXTS = "dir-contexts";
     String DIRECT_VERIFICATION = "direct-verification";
 
     String EMPTY = "empty";
@@ -257,6 +258,7 @@ interface ElytronDescriptionConstants {
     String REALM_MAPPING = "realm-mapping";
     String REALM_NAME = "realm-name";
     String REALMS = "realms";
+    String REFERRAL_MODE = "referral-mode";
     String REGEX_NAME_REWRITER = "regex-name-rewriter";
     String REGEX_NAME_VALIDATING_REWRITER = "regex-name-validating-rewriter";
     String REGISTER = "register";

--- a/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser.java
@@ -31,6 +31,7 @@ import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CLASS_NAME;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CREDENTIAL_SECURITY_FACTORIES;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CONFIGURATION;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.DIR_CONTEXTS;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.HTTP;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.KEY;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.MAPPERS;
@@ -78,6 +79,7 @@ class ElytronSubsystemParser implements XMLElementReader<List<ModelNode>>, XMLEl
     private final MapperParser mapperParser = new MapperParser();
     private final SaslParser saslParser = new SaslParser();
     private final HttpParser httpParser = new HttpParser();
+    private final DirContextParser dirContextParser = new DirContextParser();
 
     /**
      * {@inheritDoc}
@@ -125,6 +127,9 @@ class ElytronSubsystemParser implements XMLElementReader<List<ModelNode>>, XMLEl
                     break;
                 case TLS:
                     tlsParser.readTls(parentAddress, reader, operations);
+                    break;
+                case DIR_CONTEXTS:
+                    dirContextParser.readDirContexts(parentAddress, reader, operations);
                     break;
                 default:
                     throw unexpectedElement(reader);
@@ -366,6 +371,7 @@ class ElytronSubsystemParser implements XMLElementReader<List<ModelNode>>, XMLEl
         httpParser.writeHttp(model, writer);
         saslParser.writeSasl(model, writer);
         tlsParser.writeTLS(model, writer);
+        dirContextParser.writeDirContexts(model, writer);
 
         writer.writeEndElement();
     }

--- a/src/main/java/org/wildfly/extension/elytron/RealmParser.java
+++ b/src/main/java/org/wildfly/extension/elytron/RealmParser.java
@@ -79,7 +79,6 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.jboss.staxmapper.XMLExtendedStreamWriter;
 import org.wildfly.extension.elytron.JdbcRealmDefinition.PasswordMapperObjectDefinition;
 import org.wildfly.extension.elytron.JdbcRealmDefinition.PrincipalQueryAttributes;
-import org.wildfly.extension.elytron.LdapRealmDefinition.DirContextObjectDefinition;
 import org.wildfly.extension.elytron.LdapRealmDefinition.IdentityMappingObjectDefinition;
 
 /**
@@ -476,6 +475,9 @@ class RealmParser {
                     case DIRECT_VERIFICATION:
                         LdapRealmDefinition.DIRECT_VERIFICATION.parseAndSetParameter(value, addRealm, reader);
                         break;
+                    case DIR_CONTEXT:
+                        LdapRealmDefinition.DIR_CONTEXT.parseAndSetParameter(value, addRealm, reader);
+                        break;
                     default:
                         throw unexpectedAttribute(reader, i);
                 }
@@ -493,11 +495,6 @@ class RealmParser {
             String localName = reader.getLocalName();
 
             switch (localName) {
-                case DIR_CONTEXT:
-                    ModelNode dirContextNode = readModelNode(DirContextObjectDefinition.ATTRIBUTES, reader, null);
-                    requireNoContent(reader);
-                    addRealm.get(DIR_CONTEXT).set(dirContextNode);
-                    break;
                 case IDENTITY_MAPPING:
                     ModelNode principalMappingNode = readModelNode(IdentityMappingObjectDefinition.ATTRIBUTES, reader, (parentNode, reader1) -> {
 
@@ -751,10 +748,11 @@ class RealmParser {
             for (String name : realms.keys()) {
                 writer.writeStartElement(LDAP_REALM);
                 writer.writeAttribute(NAME, name);
-                ModelNode ldapRealmNode = realms.require(name);
-                LdapRealmDefinition.DIRECT_VERIFICATION.marshallAsElement(ldapRealmNode, false, writer);
 
-                writeObjectTypeAttribute(DIR_CONTEXT, DirContextObjectDefinition.ATTRIBUTES, ldapRealmNode.get(DIR_CONTEXT), writer, null);
+                ModelNode ldapRealmNode = realms.require(name);
+                LdapRealmDefinition.DIR_CONTEXT.marshallAsAttribute(ldapRealmNode, false, writer);
+                LdapRealmDefinition.DIRECT_VERIFICATION.marshallAsAttribute(ldapRealmNode, false, writer);
+
                 writeObjectTypeAttribute(IDENTITY_MAPPING, IdentityMappingObjectDefinition.ATTRIBUTES, ldapRealmNode.get(IDENTITY_MAPPING), writer, (modelNode, writer1) -> {
                     ModelNode attributeMappingNode = modelNode.get(ATTRIBUTE_MAPPING);
                     if (attributeMappingNode.isDefined()) {

--- a/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -833,3 +833,15 @@ elytron.server-ssl-context.ssl-session.peer-certificates.version=The certificate
 elytron.server-ssl-context.ssl-session.invalidate=Invalidate the SSLSession (Note: This does not terminate current connections, only prevents future connections from joining or resuming this session).
 
 
+##############
+# DirContext #
+##############
+elytron.dir-context=The configuration to connect to a directory (LDAP) server.
+elytron.dir-context.add=Add the DirContext definition.
+elytron.dir-context.remove=Remove the DirContext definition.
+elytron.dir-context.url=The connection url.
+elytron.dir-context.authentication-level=The authentication level (security level) to use.
+elytron.dir-context.principal=The principal to authenticate and connect to the LDAP server.
+elytron.dir-context.credential=The credential to authenticate and connect to the LDAP server.
+elytron.dir-context.enable-connection-pooling=Indicates if connection pooling is enabled.
+elytron.dir-context.referral-mode=If referrals should be followed.

--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -39,6 +39,7 @@
             <xs:element name="http" type="httpType" minOccurs="0" />    
             <xs:element name="sasl" type="saslType" minOccurs="0" />
             <xs:element name="tls" type="tlsType" minOccurs="0" />
+            <xs:element name="dir-contexts" type="dirContextsType" minOccurs="0" />
         </xs:all>
     </xs:complexType>
 
@@ -658,9 +659,15 @@
         <xs:complexContent>
             <xs:extension base="realmType">
                 <xs:all>
-                    <xs:element name="dir-context" type="dirContextType" nillable="false"/>
                     <xs:element name="identity-mapping" type="identityMappingType" nillable="false"/>
                 </xs:all>
+                <xs:attribute name="dir-context" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of dir-context used to connect to the LDAP server.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
                 <xs:attribute name="direct-verification" type="xs:boolean" use="optional" default="false">
                     <xs:annotation>
                         <xs:documentation>
@@ -702,12 +709,31 @@
         </xs:complexContent>
     </xs:complexType>
 
+
+    <xs:complexType name="dirContextsType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration options that define how to connect to the LDAP server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="dir-context" type="dirContextType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:choice>
+    </xs:complexType>
+
     <xs:complexType name="dirContextType">
         <xs:annotation>
             <xs:documentation>
-                The configuration options that define how principals are mapped to their corresponding entries in the underlying LDAP server.
+                The configuration options that define how to connect to the LDAP server.
             </xs:documentation>
         </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the connection. Allows to refer the DirContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="url" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>
@@ -718,21 +744,25 @@
         <xs:attribute name="authentication-level" type="xs:string" use="optional" default="simple">
             <xs:annotation>
                 <xs:documentation>
-                    The authentication level.
+                    The authentication level (security level) to use.
+                    Corresponds to SECURITY_AUTHENTICATION environment property.
+                    Allowed values: "none", "simple", "strong".
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="principal" type="xs:string" use="required">
+        <xs:attribute name="principal" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The principal to authenticate and connect to the LDAP server.
+                    Can be omitted if authentication-level is "none" (anonymous).
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="credential" type="xs:string" use="required">
+        <xs:attribute name="credential" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The credential to authenticate and connect to the LDAP server.
+                    Can be omitted if authentication-level is "none" (anonymous).
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/src/test/java/org/wildfly/extension/elytron/RealmsTestCase.java
+++ b/src/test/java/org/wildfly/extension/elytron/RealmsTestCase.java
@@ -29,6 +29,8 @@ import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.msc.service.ServiceName;
 import org.junit.Assert;
 import org.junit.Test;
+import org.wildfly.common.function.ExceptionSupplier;
+import org.wildfly.security.auth.realm.ldap.DelegatingLdapContext;
 import org.wildfly.security.auth.server.ModifiableRealmIdentity;
 import org.wildfly.security.auth.server.ModifiableSecurityRealm;
 import org.wildfly.security.auth.server.RealmIdentity;
@@ -41,6 +43,9 @@ import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.interfaces.OneTimePassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.OneTimePasswordSpec;
+
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
 
 /**
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
@@ -107,6 +112,15 @@ public class RealmsTestCase extends AbstractSubsystemTest {
             Assert.fail(services.getBootError().toString());
         }
 
+        // test DirContext first
+        ServiceName serviceNameDirContext = Capabilities.DIR_CONTEXT_RUNTIME_CAPABILITY.getCapabilityServiceName("ldap1");
+        ExceptionSupplier<DirContext, NamingException> dirContextSup = (ExceptionSupplier<DirContext, NamingException>) services.getContainer().getService(serviceNameDirContext).getValue();
+        DirContext dirContext = dirContextSup.get();
+        Assert.assertNotNull(dirContext);
+        Assert.assertTrue(dirContext instanceof DelegatingLdapContext);
+        dirContext.close();
+
+        // test LdapRealm
         ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName("LdapRealm");
         ModifiableSecurityRealm securityRealm = (ModifiableSecurityRealm) services.getContainer().getService(serviceName).getValue();
         Assert.assertNotNull(securityRealm);

--- a/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
+++ b/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
@@ -1,5 +1,9 @@
 <!-- for needs of RealmsTestCase -->
 <subsystem xmlns="urn:wildfly:elytron:1.0">
+    <dir-contexts>
+        <dir-context name="ldap1" url="ldap://localhost:11391/" authentication-level="none"/>
+        <dir-context name="ldap2" url="ldap://localhost:11391/" principal="uid=server,dc=elytron,dc=wildfly,dc=org" credential="serverPassword"/>
+    </dir-contexts>
     <security-realms>
 
         <properties-realm name="TestingPropertyRealm1">
@@ -10,8 +14,7 @@
             <file path="filesystem-realm" relative-to="jboss.server.config.dir" />
         </filesystem-realm>
 
-        <ldap-realm name="LdapRealm">
-            <dir-context url="ldap://localhost:11391/" principal="uid=server,dc=elytron,dc=wildfly,dc=org" credential="serverPassword"/>
+        <ldap-realm name="LdapRealm" direct-verification="false" dir-context="ldap2">
             <identity-mapping rdn-identifier="uid" search-base-dn="dc=elytron,dc=wildfly,dc=org" use-recursive-search="true" iterator-filter="(uid=*)" new-identity-parent-dn="dc=elytron,dc=wildfly,dc=org">
                 <attribute-mapping>
                     <attribute from="uid" to="userName"/>

--- a/src/test/resources/org/wildfly/extension/elytron/security-realms.xml
+++ b/src/test/resources/org/wildfly/extension/elytron/security-realms.xml
@@ -9,6 +9,10 @@
             </key-store>
         </key-stores>
     </tls>
+    <dir-contexts>
+        <dir-context name="dircontext1" url="ldap://localhost:11390" principal="uid=server,dc=elytron,dc=wildfly,dc=org" credential="serverPassword" enable-connection-pooling="true" />
+        <dir-context name="dircontext2" url="ldap://localhost:11390" />
+    </dir-contexts>
     <security-realms>
         <aggregate-realm name="AggregateOne" authentication-realm="RealmThree" authorization-realm="RealmFour" />
         <custom-realm name="CustomOne" class-name="org.wildfly.security.ElytronRealm" />
@@ -64,8 +68,7 @@
                 </attribute-mapping>
             </principal-query>
         </jdbc-realm>
-        <ldap-realm name="LdapRealmWithAttributeMapping">
-            <dir-context url="ldap://localhost:11390" principal="uid=server,dc=elytron,dc=wildfly,dc=org" credential="serverPassword" enable-connection-pooling="true" />
+        <ldap-realm name="LdapRealmWithAttributeMapping" dir-context="dircontext1">
             <identity-mapping rdn-identifier="uid" use-recursive-search="true" search-base-dn="dc=elytron,dc=wildfly,dc=org" iterator-filter="(uid=*)" new-identity-parent-dn="dc=elytron,dc=wildfly,dc=org">
                 <user-password-mapper from="userPassword" writable="true" verifiable="true"/>
                 <attribute-mapping>
@@ -86,8 +89,7 @@
                 </new-identity-attributes>
             </identity-mapping>
         </ldap-realm>
-        <ldap-realm name="LdapRealmWithoutAttributeMapping">
-            <dir-context url="ldap://localhost:11390" principal="uid=server,dc=elytron,dc=wildfly,dc=org" credential="serverPassword" enable-connection-pooling="true" />
+        <ldap-realm name="LdapRealmWithoutAttributeMapping" dir-context="dircontext2" direct-verification="true">
             <identity-mapping rdn-identifier="uid" use-recursive-search="true" search-base-dn="dc=elytron,dc=wildfly,dc=org"/>
         </ldap-realm>
         <filesystem-realm name="RealmSeven" levels="3">


### PR DESCRIPTION
* DirContext definition in subsystem from LDAP realm to standalone block
* Allowed principal+password omitting (for AUTHENTICATION_LEVEL="none")

Depends on https://github.com/wildfly-security/wildfly-elytron/pull/485