### PR TITLE
[WFLY-7154] poor description of session-timeout,maximum-session-cache-size attributes.

### DIFF
--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -3137,14 +3137,14 @@
         <xs:attribute name="maximum-session-cache-size" type="xs:int" default="0">
             <xs:annotation>
                 <xs:documentation>
-                    The maximum number of SSL sessions in the cache.
+                    The maximum number of SSL sessions in the cache. The default value zero means there is no limit.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="session-timeout" type="xs:int" default="0">
             <xs:annotation>
                 <xs:documentation>
-                    The timeout for SSL sessions.
+                    The timeout for SSL sessions, in seconds. The default value zero means there is no limit.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -3226,14 +3226,14 @@
         <xs:attribute name="maximum-session-cache-size" type="xs:int" default="0">
             <xs:annotation>
                 <xs:documentation>
-                    The maximum number of SSL sessions in the cache.
+                    The maximum number of SSL sessions in the cache. The default value zero means there is no limit.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="session-timeout" type="xs:int" default="0">
             <xs:annotation>
                 <xs:documentation>
-                    The timeout for SSL sessions.
+                    The timeout for SSL sessions, in seconds. The default value zero means there is no limit.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>


### PR DESCRIPTION
WildFly: https://issues.jboss.org/browse/WFLY-7154
