### PR TITLE
[WFLY-4351] Resolves #239 Export setUserCipherSuiteOrder on SSLContext resource

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -359,6 +359,7 @@ interface ElytronDescriptionConstants {
     String UNLESS = "unless";
     String URL = "url";
     String USE_RECURSIVE_SEARCH = "use-recursive-search";
+    String USE_CIPHER_SUITES_ORDER = "use-cipher-suites-order";
     String USERS_PROPERTIES = "users-properties";
     String USER_PASSWORD_MAPPER = "user-password-mapper";
 

--- a/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -161,6 +161,13 @@ class SSLDefinitions {
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
+    static final SimpleAttributeDefinition USE_CIPHER_SUITES_ORDER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.USE_CIPHER_SUITES_ORDER, ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(true))
+            .setMinSize(1)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+
     static final SimpleAttributeDefinition MAXIMUM_SESSION_CACHE_SIZE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.MAXIMUM_SESSION_CACHE_SIZE, ModelType.INT, true)
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(0))
@@ -390,7 +397,7 @@ class SSLDefinitions {
                 .build();
 
         AttributeDefinition[] attributes = new AttributeDefinition[] { SECURITY_DOMAIN, CIPHER_SUITE_FILTER, PROTOCOLS, WANT_CLIENT_AUTH, NEED_CLIENT_AUTH, AUTHENTICATION_OPTIONAL,
-                MAXIMUM_SESSION_CACHE_SIZE, SESSION_TIMEOUT, KEY_MANAGERS, TRUST_MANAGERS, providerLoaderDefinition };
+                USE_CIPHER_SUITES_ORDER, MAXIMUM_SESSION_CACHE_SIZE, SESSION_TIMEOUT, KEY_MANAGERS, TRUST_MANAGERS, providerLoaderDefinition };
 
         return new SSLContextDefinition(ElytronDescriptionConstants.SERVER_SSL_CONTEXT, new TrivialAddHandler<SSLContext>(SSLContext.class, attributes, SSL_CONTEXT_RUNTIME_CAPABILITY) {
             @Override
@@ -406,6 +413,7 @@ class SSLDefinitions {
                 final boolean wantClientAuth = WANT_CLIENT_AUTH.resolveModelAttribute(context, model).asBoolean();
                 final boolean needClientAuth = NEED_CLIENT_AUTH.resolveModelAttribute(context, model).asBoolean();
                 final boolean authenticationOptional = AUTHENTICATION_OPTIONAL.resolveModelAttribute(context, model).asBoolean();
+                final boolean useCipherSuitesOrder = USE_CIPHER_SUITES_ORDER.resolveModelAttribute(context, model).asBoolean();
                 final int maximumSessionCacheSize = MAXIMUM_SESSION_CACHE_SIZE.resolveModelAttribute(context, model).asInt();
                 final int sessionTimeout = SESSION_TIMEOUT.resolveModelAttribute(context, model).asInt();
 
@@ -427,6 +435,7 @@ class SSLDefinitions {
                     builder.setWantClientAuth(wantClientAuth)
                            .setNeedClientAuth(needClientAuth)
                            .setAuthenticationOptional(authenticationOptional)
+                           .setUseCipherSuitesOrder(useCipherSuitesOrder)
                            .setSessionCacheSize(maximumSessionCacheSize)
                            .setSessionTimeout(sessionTimeout);
 
@@ -447,7 +456,7 @@ class SSLDefinitions {
                 .build();
 
         AttributeDefinition[] attributes = new AttributeDefinition[] { CIPHER_SUITE_FILTER, PROTOCOLS,
-                MAXIMUM_SESSION_CACHE_SIZE, SESSION_TIMEOUT, KEY_MANAGERS, TRUST_MANAGERS, providerLoaderDefinition };
+                USE_CIPHER_SUITES_ORDER, MAXIMUM_SESSION_CACHE_SIZE, SESSION_TIMEOUT, KEY_MANAGERS, TRUST_MANAGERS, providerLoaderDefinition };
 
         return new SSLContextDefinition(ElytronDescriptionConstants.CLIENT_SSL_CONTEXT, new TrivialAddHandler<SSLContext>(SSLContext.class, attributes, SSL_CONTEXT_RUNTIME_CAPABILITY) {
             @Override
@@ -459,6 +468,7 @@ class SSLDefinitions {
 
                 final List<String> protocols = PROTOCOLS.unwrap(context, model);
                 final String cipherSuiteFilter = asStringIfDefined(context, CIPHER_SUITE_FILTER, model);
+                final boolean useCipherSuitesOrder = USE_CIPHER_SUITES_ORDER.resolveModelAttribute(context, model).asBoolean();
                 final int maximumSessionCacheSize = MAXIMUM_SESSION_CACHE_SIZE.resolveModelAttribute(context, model).asInt(); // client+server
                 final int sessionTimeout = SESSION_TIMEOUT.resolveModelAttribute(context, model).asInt(); // client+server
 
@@ -476,6 +486,7 @@ class SSLDefinitions {
                             EnumSet.copyOf(protocols.stream().map(Protocol::valueOf).collect(Collectors.toList()))
                     ));
                     builder.setClientMode(true)
+                           .setUseCipherSuitesOrder(useCipherSuitesOrder)
                            .setSessionCacheSize(maximumSessionCacheSize)
                            .setSessionTimeout(sessionTimeout);
 

--- a/src/main/java/org/wildfly/extension/elytron/TlsParser.java
+++ b/src/main/java/org/wildfly/extension/elytron/TlsParser.java
@@ -253,6 +253,9 @@ class TlsParser {
                     case AUTHENTICATION_OPTIONAL:
                         SSLDefinitions.AUTHENTICATION_OPTIONAL.parseAndSetParameter(value, addServerSSLContext, reader);
                         break;
+                    case USE_CIPHER_SUITES_ORDER:
+                        SSLDefinitions.USE_CIPHER_SUITES_ORDER.parseAndSetParameter(value, addServerSSLContext, reader);
+                        break;
                     case MAXIMUM_SESSION_CACHE_SIZE:
                         SSLDefinitions.MAXIMUM_SESSION_CACHE_SIZE.parseAndSetParameter(value, addServerSSLContext, reader);
                         break;
@@ -334,6 +337,9 @@ class TlsParser {
                         break;
                     case AUTHENTICATION_OPTIONAL:
                         SSLDefinitions.AUTHENTICATION_OPTIONAL.parseAndSetParameter(value, addServerSSLContext, reader);
+                        break;
+                    case USE_CIPHER_SUITES_ORDER:
+                        SSLDefinitions.USE_CIPHER_SUITES_ORDER.parseAndSetParameter(value, addServerSSLContext, reader);
                         break;
                     case MAXIMUM_SESSION_CACHE_SIZE:
                         SSLDefinitions.MAXIMUM_SESSION_CACHE_SIZE.parseAndSetParameter(value, addServerSSLContext, reader);
@@ -772,6 +778,7 @@ class TlsParser {
                 SSLDefinitions.WANT_CLIENT_AUTH.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.NEED_CLIENT_AUTH.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.AUTHENTICATION_OPTIONAL.marshallAsAttribute(serverSSLContext, writer);
+                SSLDefinitions.USE_CIPHER_SUITES_ORDER.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.MAXIMUM_SESSION_CACHE_SIZE.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.SESSION_TIMEOUT.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.KEY_MANAGERS.marshallAsAttribute(serverSSLContext, writer);
@@ -802,6 +809,7 @@ class TlsParser {
                 SSLDefinitions.CIPHER_SUITE_FILTER.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.PROTOCOLS.getAttributeMarshaller().marshallAsAttribute(SSLDefinitions.PROTOCOLS, serverSSLContext, false, writer);
                 SSLDefinitions.MAXIMUM_SESSION_CACHE_SIZE.marshallAsAttribute(serverSSLContext, writer);
+                SSLDefinitions.USE_CIPHER_SUITES_ORDER.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.SESSION_TIMEOUT.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.KEY_MANAGERS.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.TRUST_MANAGERS.marshallAsAttribute(serverSSLContext, writer);

--- a/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -870,6 +870,7 @@ elytron.client-ssl-context.remove=Remove the SSLContext definition.
 #Attributes
 elytron.client-ssl-context.cipher-suite-filter=The filter to apply to specify the enabled cipher suites.
 elytron.client-ssl-context.protocols=The enabled protocols.
+elytron.client-ssl-context.use-cipher-suites-order=To honor local cipher suites preference.
 elytron.client-ssl-context.maximum-session-cache-size=The maximum number of SSL sessions to be cached.
 elytron.client-ssl-context.session-timeout=The timeout for SSL sessions.
 elytron.client-ssl-context.key-managers=Reference to the key managers to use within the SSLContext.
@@ -938,6 +939,7 @@ elytron.server-ssl-context.protocols=The enabled protocols.
 elytron.server-ssl-context.want-client-auth=Set wantClientAuth on the underlying SSLContext - if a security domain is referenced this will automatically be set to true.
 elytron.server-ssl-context.need-client-auth=Set needClientAuth on the underlying SSLContext.
 elytron.server-ssl-context.authentication-optional=Allow for a SSLSession to still be established even if the authentication failed, this allows a fall through to use other authentication mechanisms.
+elytron.server-ssl-context.use-cipher-suites-order=To honor local cipher suites preference.
 elytron.server-ssl-context.maximum-session-cache-size=The maximum number of SSL sessions to be cached.
 elytron.server-ssl-context.session-timeout=The timeout for SSL sessions.
 elytron.server-ssl-context.key-managers=Reference to the key managers to use within the SSLContext.

--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -3037,6 +3037,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="use-cipher-suites-order" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Configure the SSLContext to honor local cipher suites preference.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="maximum-session-cache-size" type="xs:int" default="0">
             <xs:annotation>
                 <xs:documentation>
@@ -3116,6 +3123,13 @@
             <xs:annotation>
                 <xs:documentation>
                     List of protocols supported by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="use-cipher-suites-order" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Configure the SSLContext to honor local cipher suites preference.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
+++ b/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -85,7 +85,7 @@ public class TlsTestCase extends AbstractSubsystemTest {
         testCommunication(listeningSocket, serverSocket, clientSocket, "OU=Elytron,O=Elytron,C=CZ,ST=Elytron,CN=localhost", "OU=Elytron,O=Elytron,C=UK,ST=Elytron,CN=Firefly");
     }
 
-    @Test(expected = SSLPeerUnverifiedException.class)
+    @Test(expected = SSLHandshakeException.class)
     public void testSslServiceAuthRequiredButNotProvided() throws Throwable {
         SSLServerSocketFactory serverSocketFactory = getSslContext("ServerSslContextAuth").getServerSocketFactory();
         SSLSocketFactory clientSocketFactory = getSslContext("ClientSslContextNoAuth").getSocketFactory();

--- a/src/test/resources/org/wildfly/extension/elytron/tls-test.xml
+++ b/src/test/resources/org/wildfly/extension/elytron/tls-test.xml
@@ -30,11 +30,11 @@
         <server-ssl-contexts>
             <server-ssl-context name="ServerSslContextNoAuth" key-managers="ServerKeyManager" trust-managers="CaTrustManager"/>
             <server-ssl-context name="ServerSslContextAuth" protocols="TLSv1_3 TLSv1_2 TLSv1_1" key-managers="ServerKeyManager" trust-managers="CaTrustManager"
-                                want-client-auth="true" need-client-auth="true" authentication-optional="false"/>
+                                want-client-auth="true" need-client-auth="true" authentication-optional="false" use-cipher-suites-order="false"/>
         </server-ssl-contexts>
         <client-ssl-contexts>
             <client-ssl-context name="ClientSslContextNoAuth" trust-managers="CaTrustManager" />
-            <client-ssl-context name="ClientSslContextAuth" protocols="SSLv2 SSLv3 TLSv1 TLSv1_3 TLSv1_2" key-managers="ClientKeyManager" trust-managers="CaTrustManager" />
+            <client-ssl-context name="ClientSslContextAuth" protocols="SSLv2 SSLv3 TLSv1 TLSv1_3 TLSv1_2" key-managers="ClientKeyManager" trust-managers="CaTrustManager" use-cipher-suites-order="false"/>
         </client-ssl-contexts>
     </tls>
 </subsystem>

--- a/src/test/resources/org/wildfly/extension/elytron/tls.xml
+++ b/src/test/resources/org/wildfly/extension/elytron/tls.xml
@@ -24,11 +24,11 @@
             <trust-manager name="serverTrust2" algorithm="SunX509" key-store="jks_store" provider-loader="test" provider="first" />
         </trust-managers>
         <server-ssl-contexts>
-            <server-ssl-context name="server" protocols="TLSv1_2" want-client-auth="true" need-client-auth="true" authentication-optional="true" maximum-session-cache-size="10"
+            <server-ssl-context name="server" protocols="TLSv1_2" want-client-auth="true" need-client-auth="true" authentication-optional="true" use-cipher-suites-order="false" maximum-session-cache-size="10"
                 session-timeout="120" key-managers="serverKey" trust-managers="serverTrust" />
         </server-ssl-contexts>
         <client-ssl-contexts>
-            <client-ssl-context name="client" protocols="TLSv1_3 TLSv1_2" key-managers="clientKey" trust-managers="serverTrust" />
+            <client-ssl-context name="client" protocols="TLSv1_3 TLSv1_2" use-cipher-suites-order="true" key-managers="clientKey" trust-managers="serverTrust" />
         </client-ssl-contexts>
     </tls>
 </subsystem>


### PR DESCRIPTION
Related to https://issues.jboss.org/browse/ELY-643 / https://github.com/wildfly-security/elytron-subsystem/issues/239
Depends on https://github.com/wildfly-security/wildfly-elytron/pull/499