### PR TITLE
[WFLY-7224] Missing validation check for simple-regex-realm-mapper and mapped-regex-realm-mapper in Elytron subsystem.

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/MapperParser.java
+++ b/src/main/java/org/wildfly/extension/elytron/MapperParser.java
@@ -840,7 +840,7 @@ class MapperParser {
                         name = value;
                         break;
                     case PATTERN:
-                        RegexAttributeDefinitions.PATTERN.parseAndSetParameter(value, addRealmMapper, reader);
+                        RegexAttributeDefinitions.PATTERN_CAPTURE_GROUP.parseAndSetParameter(value, addRealmMapper, reader);
                         break;
                     case DELEGATE_REALM_MAPPER:
                         RealmMapperDefinitions.DELEGATE_REALM_MAPPER.parseAndSetParameter(value, addRealmMapper, reader);
@@ -884,7 +884,7 @@ class MapperParser {
                         name = value;
                         break;
                     case PATTERN:
-                        RegexAttributeDefinitions.PATTERN.parseAndSetParameter(value, addRealmMapper, reader);
+                        RegexAttributeDefinitions.PATTERN_CAPTURE_GROUP.parseAndSetParameter(value, addRealmMapper, reader);
                         break;
                     case DELEGATE_REALM_MAPPER:
                         RealmMapperDefinitions.DELEGATE_REALM_MAPPER.parseAndSetParameter(value, addRealmMapper, reader);
@@ -1563,7 +1563,7 @@ class MapperParser {
                 ModelNode realmMapper = nameRewriters.require(name);
                 writer.writeStartElement(SIMPLE_REGEX_REALM_MAPPER);
                 writer.writeAttribute(NAME, name);
-                RegexAttributeDefinitions.PATTERN.marshallAsAttribute(realmMapper, writer);
+                RegexAttributeDefinitions.PATTERN_CAPTURE_GROUP.marshallAsAttribute(realmMapper, writer);
                 RealmMapperDefinitions.DELEGATE_REALM_MAPPER.marshallAsAttribute(realmMapper, writer);
                 writer.writeEndElement();
             }
@@ -1582,7 +1582,7 @@ class MapperParser {
                 ModelNode realmMapper = nameRewriters.require(name);
                 writer.writeStartElement(MAPPED_REGEX_REALM_MAPPER);
                 writer.writeAttribute(NAME, name);
-                RegexAttributeDefinitions.PATTERN.marshallAsAttribute(realmMapper, writer);
+                RegexAttributeDefinitions.PATTERN_CAPTURE_GROUP.marshallAsAttribute(realmMapper, writer);
                 RealmMapperDefinitions.DELEGATE_REALM_MAPPER.marshallAsAttribute(realmMapper, writer);
                 RealmMapperDefinitions.REALM_REALM_MAP.marshallAsElement(realmMapper, writer);
                 writer.writeEndElement();

--- a/src/main/java/org/wildfly/extension/elytron/RealmMapperDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/RealmMapperDefinitions.java
@@ -24,7 +24,7 @@ import static org.wildfly.extension.elytron.ElytronDescriptionConstants.FROM;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.REALM_MAPPING;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.TO;
 import static org.wildfly.extension.elytron.ElytronExtension.asStringIfDefined;
-import static org.wildfly.extension.elytron.RegexAttributeDefinitions.PATTERN;
+import static org.wildfly.extension.elytron.RegexAttributeDefinitions.PATTERN_CAPTURE_GROUP;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -108,7 +108,7 @@ class RealmMapperDefinitions {
 
     private static class SimpleRegexRealmMapperDefinition extends SimpleResourceDefinition {
 
-        private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { PATTERN, DELEGATE_REALM_MAPPER };
+        private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { PATTERN_CAPTURE_GROUP, DELEGATE_REALM_MAPPER };
 
         private static final AbstractAddStepHandler ADD = new SimpleRegexRealmMapperAddHandler(ATTRIBUTES);
         private static final OperationStepHandler REMOVE = new TrivialCapabilityServiceRemoveHandler(ADD, REALM_MAPPER_RUNTIME_CAPABILITY);
@@ -145,7 +145,7 @@ class RealmMapperDefinitions {
             RuntimeCapability<Void> runtimeCapability = REALM_MAPPER_RUNTIME_CAPABILITY.fromBaseCapability(context.getCurrentAddressValue());
             ServiceName realmMapperName = runtimeCapability.getCapabilityServiceName(RealmMapper.class);
 
-            final String pattern = PATTERN.resolveModelAttribute(context, model).asString();
+            final String pattern = PATTERN_CAPTURE_GROUP.resolveModelAttribute(context, model).asString();
             String delegateRealmMapper = asStringIfDefined(context, DELEGATE_REALM_MAPPER, model);
 
             final InjectedValue<RealmMapper> delegateRealmMapperInjector = new InjectedValue<RealmMapper>();
@@ -178,7 +178,7 @@ class RealmMapperDefinitions {
 
     private static class MappedRegexRealmMapperDefinition extends SimpleResourceDefinition {
 
-        private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { PATTERN, REALM_REALM_MAP, DELEGATE_REALM_MAPPER };
+        private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { PATTERN_CAPTURE_GROUP, REALM_REALM_MAP, DELEGATE_REALM_MAPPER };
 
         private static final AbstractAddStepHandler ADD = new MappedRegexRealmMapperAddHandler(ATTRIBUTES);
         private static final OperationStepHandler REMOVE = new TrivialCapabilityServiceRemoveHandler(ADD, REALM_MAPPER_RUNTIME_CAPABILITY);
@@ -215,7 +215,7 @@ class RealmMapperDefinitions {
             RuntimeCapability<Void> runtimeCapability = REALM_MAPPER_RUNTIME_CAPABILITY.fromBaseCapability(context.getCurrentAddressValue());
             ServiceName realmMapperName = runtimeCapability.getCapabilityServiceName(RealmMapper.class);
 
-            final String pattern = PATTERN.resolveModelAttribute(context, model).asString();
+            final String pattern = PATTERN_CAPTURE_GROUP.resolveModelAttribute(context, model).asString();
 
             ModelNode realmMapList = REALM_REALM_MAP.resolveModelAttribute(context, model);
             Set<String> names = realmMapList.keys();

--- a/src/main/java/org/wildfly/extension/elytron/RegexAttributeDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/RegexAttributeDefinitions.java
@@ -43,6 +43,13 @@ class RegexAttributeDefinitions {
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
         .build();
 
+    static final SimpleAttributeDefinition PATTERN_CAPTURE_GROUP = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PATTERN, ModelType.STRING, false)
+            .setAllowExpression(true)
+            .setValidator(new CaptureGroupRexExValidator())
+            .setMinSize(1)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+
     private static class RexExValidator extends StringLengthValidator {
 
         private RexExValidator() {
@@ -59,6 +66,22 @@ class RegexAttributeDefinitions {
                 Pattern.compile(pattern);
             } catch (IllegalArgumentException e) {
                 throw ROOT_LOGGER.invalidRegularExpression(pattern, e);
+            }
+        }
+
+    }
+
+    private static class CaptureGroupRexExValidator extends RexExValidator {
+
+        @Override
+        public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            super.validateParameter(parameterName, value);
+
+            String pattern = value.asString();
+
+            final int groupCount = Pattern.compile(pattern).matcher("").groupCount();
+            if (groupCount < 1) {
+                throw ROOT_LOGGER.patternRequiresCaptureGroup(pattern);
             }
         }
 

--- a/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -269,5 +269,6 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 1012, value = "Unexpected password type [%s].")
     OperationFailedException unexpectedPasswordType(final String passwordType);
 
-
+    @Message(id = 1013, value = "Pattern [%s] requires a capture group")
+    OperationFailedException patternRequiresCaptureGroup(final String pattern);
 }

--- a/src/test/resources/org/wildfly/extension/elytron/domain.xml
+++ b/src/test/resources/org/wildfly/extension/elytron/domain.xml
@@ -25,7 +25,7 @@
         
         <custom-permission-mapper name="PermissionMapper" class-name="org.wildfly.elytron.PermissionMapper" />
         <custom-principal-decoder name="CustomPrincipalDecoder" class-name="org.wildfly.elytron.PrincipalDecoder" />
-        <simple-regex-realm-mapper name="RegexMapper" pattern="f" />
+        <simple-regex-realm-mapper name="RegexMapper" pattern="(f)" />
         
         <empty-role-decoder name="EmptyRoleDecoder" />
         

--- a/src/test/resources/org/wildfly/extension/elytron/mappers.xml
+++ b/src/test/resources/org/wildfly/extension/elytron/mappers.xml
@@ -52,8 +52,8 @@
         <x500-attribute-principal-decoder name="X500PrincipalDecoderThree" oid="2.5.4.3" joiner="." start-segment="2" maximum-segments="6" reverse="true" required-oids="2.5.4.3 2.5.4.11"/>
 
         <custom-realm-mapper name="CustomRealmOne" class-name="org.wildfly.elytron.CustomRealmMapper" module="c.d" />
-        <simple-regex-realm-mapper name="SimpleOne" pattern=".?" delegate-realm-mapper="CustomRealmOne" />
-        <mapped-regex-realm-mapper name="MappedOne" pattern=".?" delegate-realm-mapper="SimpleOne">
+        <simple-regex-realm-mapper name="SimpleOne" pattern="(.?)" delegate-realm-mapper="CustomRealmOne" />
+        <mapped-regex-realm-mapper name="MappedOne" pattern="(.?)" delegate-realm-mapper="SimpleOne">
             <realm-mapping from="a" to="b" />
             <realm-mapping from="c" to="d" />
         </mapped-regex-realm-mapper>


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-7224