### PR TITLE
[WFLY-7254] pattern-filter disappears if predefined-filter is used for configurable-sasl-server-factory in Elytron subsystem

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -271,4 +271,7 @@ public interface ElytronSubsystemMessages extends BasicLogger {
 
     @Message(id = 1013, value = "Pattern [%s] requires a capture group")
     OperationFailedException patternRequiresCaptureGroup(final String pattern);
+
+    @Message(id = 1014, value = "Invalid [%s] definition.")
+    OperationFailedException invalidDefinition(final String property);
 }


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-7254
