### PR TITLE
[WFLY-7278] Added sun.jdk into module.xml

### DIFF
--- a/src/main/resources/module/main/module.xml
+++ b/src/main/resources/module/main/module.xml
@@ -29,6 +29,7 @@
 
     <dependencies>
         <module name="javax.api"/>
+        <module name="sun.jdk"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>


### PR DESCRIPTION
The LDAP context creation use (in JDK) reflection to obtain LdapCtxFactory.
(In most cases was working because it was loaded using "org.wildfly.extension.elytron:main" module classloader)

https://issues.jboss.org/browse/WFLY-7278