### PR TITLE
[WFLY-7314] LdapKeyStore - new-item-template object

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/TlsParser.java
+++ b/src/main/java/org/wildfly/extension/elytron/TlsParser.java
@@ -594,6 +594,8 @@ class TlsParser {
 
     private void readNewItemTemplate(ModelNode addKeyStore, XMLExtendedStreamReader reader, List<ModelNode> list) throws XMLStreamException {
         Set<String> requiredAttributes = new HashSet<String>(Arrays.asList(new String[] {NEW_ITEM_PATH, NEW_ITEM_RDN}));
+        ModelNode newItemTemplate = addKeyStore.get(NEW_ITEM_TEMPLATE);
+
         final int count = reader.getAttributeCount();
         for (int i = 0; i < count; i++) {
             final String value = reader.getAttributeValue(i);
@@ -604,10 +606,10 @@ class TlsParser {
                 requiredAttributes.remove(attribute);
                 switch (attribute) {
                     case NEW_ITEM_PATH:
-                        LdapKeyStoreDefinition.NEW_ITEM_PATH.parseAndSetParameter(value, addKeyStore, reader);
+                        LdapKeyStoreDefinition.NewItemTemplateObjectDefinition.NEW_ITEM_PATH.parseAndSetParameter(value, newItemTemplate, reader);
                         break;
                     case NEW_ITEM_RDN:
-                        LdapKeyStoreDefinition.NEW_ITEM_RDN.parseAndSetParameter(value, addKeyStore, reader);
+                        LdapKeyStoreDefinition.NewItemTemplateObjectDefinition.NEW_ITEM_RDN.parseAndSetParameter(value, newItemTemplate, reader);
                         break;
                     default:
                         throw unexpectedAttribute(reader, i);
@@ -624,7 +626,7 @@ class TlsParser {
             if (ATTRIBUTE.equals(reader.getLocalName())) {
                 ModelNode attribute = new ModelNode();
                 readLdapAttribute(attribute, reader);
-                addKeyStore.get(NEW_ITEM_ATTRIBUTES).add(attribute);
+                newItemTemplate.get(NEW_ITEM_ATTRIBUTES).add(attribute);
             } else {
                 throw unexpectedElement(reader);
             }
@@ -922,12 +924,13 @@ class TlsParser {
                     LdapKeyStoreDefinition.FILTER_CERTIFICATE.marshallAsAttribute(keyStore, writer);
                     LdapKeyStoreDefinition.FILTER_ITERATE.marshallAsAttribute(keyStore, writer);
 
-                    if (keyStore.hasDefined(NEW_ITEM_PATH)) {
+                    ModelNode newItemTemplate = keyStore.get(NEW_ITEM_TEMPLATE);
+                    if (newItemTemplate.isDefined()) {
                         writer.writeStartElement(NEW_ITEM_TEMPLATE);
-                        LdapKeyStoreDefinition.NEW_ITEM_PATH.marshallAsAttribute(keyStore, writer);
-                        LdapKeyStoreDefinition.NEW_ITEM_RDN.marshallAsAttribute(keyStore, writer);
+                        LdapKeyStoreDefinition.NewItemTemplateObjectDefinition.NEW_ITEM_PATH.marshallAsAttribute(newItemTemplate, writer);
+                        LdapKeyStoreDefinition.NewItemTemplateObjectDefinition.NEW_ITEM_RDN.marshallAsAttribute(newItemTemplate, writer);
 
-                        ModelNode newItemAttributes = keyStore.get(NEW_ITEM_ATTRIBUTES);
+                        ModelNode newItemAttributes = newItemTemplate.get(NEW_ITEM_ATTRIBUTES);
                         if (newItemAttributes.isDefined()) {
                             for (ModelNode newItemAttribute : newItemAttributes.asList()) {
                                 writer.writeStartElement(ATTRIBUTE);

--- a/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -792,11 +792,12 @@ elytron.ldap-key-store.filter-alias=The LDAP filter for obtaining item of the Ke
 elytron.ldap-key-store.filter-certificate=The LDAP filter for obtaining item of the KeyStore by certificate.
 elytron.ldap-key-store.filter-iterate=The LDAP filter for iterating over all items of the KeyStore.
 
-elytron.ldap-key-store.new-item-path=The path in LDAP, where will be newly created KeyStore items stored.
-elytron.ldap-key-store.new-item-rdn=The name of LDAP attribute, which will be used in RDN of newly created items.
-elytron.ldap-key-store.new-item-attributes=The LDAP attributes, which will be set for newly created items.
-elytron.ldap-key-store.new-item-attributes.name=The name of the LDAP attribute.
-elytron.ldap-key-store.new-item-attributes.value=The value of LDAP attribute.
+elytron.ldap-key-store.new-item-template=Configuration for item creation. Define how will look LDAP entry of newly created keystore item.
+elytron.ldap-key-store.new-item-template.new-item-path=The path in LDAP, where will be newly created KeyStore items stored.
+elytron.ldap-key-store.new-item-template.new-item-rdn=The name of LDAP attribute, which will be used in RDN of newly created items.
+elytron.ldap-key-store.new-item-template.new-item-attributes=The LDAP attributes, which will be set for newly created items.
+elytron.ldap-key-store.new-item-template.name=The name of the LDAP attribute.
+elytron.ldap-key-store.new-item-template.value=The value of LDAP attribute.
 
 elytron.ldap-key-store.alias-attribute=The name of LDAP attribute, where will be item alias stored.
 elytron.ldap-key-store.certificate-attribute=The name of LDAP attribute, where will be certificate stored.


### PR DESCRIPTION
Change suggested by Martin Chroma: new-item-* attributes should be enclosed in OBJECT.
This modify model to have the same structure as the XML already has.