### PR TITLE
[WFLY-7320] adding ldap-realm.filter-name (need for referrals)

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -128,6 +128,7 @@ interface ElytronDescriptionConstants {
     String FILTER_ALIAS = "filter-alias";
     String FILTER_BASE_DN = "filter-base-dn";
     String FILTER_CERTIFICATE = "filter-certificate";
+    String FILTER_NAME = "filter-name";
     String FILTER_ITERATE = "filter-iterate";
     String FILTERING_KEY_STORE = "filtering-key-store";
     String FILTERS = "filters";

--- a/src/main/java/org/wildfly/extension/elytron/LdapRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/LdapRealmDefinition.java
@@ -284,6 +284,11 @@ class LdapRealmDefinition extends SimpleResourceDefinition {
                 .setAllowDuplicates(true)
                 .build();
 
+        static final SimpleAttributeDefinition FILTER_NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.FILTER_NAME, ModelType.STRING, true)
+                .setAllowExpression(true)
+                .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                .build();
+
         static final SimpleAttributeDefinition ITERATOR_FILTER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ITERATOR_FILTER, ModelType.STRING, true)
                 .setAllowExpression(true)
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
@@ -297,13 +302,13 @@ class LdapRealmDefinition extends SimpleResourceDefinition {
         static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {
                 RDN_IDENTIFIER, USE_RECURSIVE_SEARCH, SEARCH_BASE_DN,
                 ATTRIBUTE_MAPPINGS,
-                ITERATOR_FILTER, NEW_IDENTITY_PARENT_DN, NEW_IDENTITY_ATTRIBUTES
+                FILTER_NAME, ITERATOR_FILTER, NEW_IDENTITY_PARENT_DN, NEW_IDENTITY_ATTRIBUTES
         };
 
         static final ObjectTypeAttributeDefinition OBJECT_DEFINITION = new ObjectTypeAttributeDefinition.Builder(ElytronDescriptionConstants.IDENTITY_MAPPING,
                     RDN_IDENTIFIER, USE_RECURSIVE_SEARCH, SEARCH_BASE_DN,
                     ATTRIBUTE_MAPPINGS,
-                    ITERATOR_FILTER, NEW_IDENTITY_PARENT_DN, NEW_IDENTITY_ATTRIBUTES,
+                FILTER_NAME, ITERATOR_FILTER, NEW_IDENTITY_PARENT_DN, NEW_IDENTITY_ATTRIBUTES,
                     UserPasswordCredentialMappingObjectDefinition.OBJECT_DEFINITION,
                     OtpCredentialMappingObjectDefinition.OBJECT_DEFINITION
                 )
@@ -453,14 +458,17 @@ class LdapRealmDefinition extends SimpleResourceDefinition {
                 }
             }
 
-            ModelNode iteratorFilterNode = IdentityMappingObjectDefinition.ITERATOR_FILTER.resolveModelAttribute(context, principalMappingNode);
+            ModelNode filterNameNode = IdentityMappingObjectDefinition.FILTER_NAME.resolveModelAttribute(context, principalMappingNode);
+            if (filterNameNode.isDefined()) {
+                identityMappingBuilder.setFilterName(filterNameNode.asString());
+            }
 
+            ModelNode iteratorFilterNode = IdentityMappingObjectDefinition.ITERATOR_FILTER.resolveModelAttribute(context, principalMappingNode);
             if (iteratorFilterNode.isDefined()) {
                 identityMappingBuilder.setIteratorFilter(iteratorFilterNode.asString());
             }
 
             ModelNode newIdentityParentDnNode = IdentityMappingObjectDefinition.NEW_IDENTITY_PARENT_DN.resolveModelAttribute(context, principalMappingNode);
-
             if (newIdentityParentDnNode.isDefined()) {
                 try {
                     identityMappingBuilder.setNewIdentityParent(new LdapName(newIdentityParentDnNode.asString()));

--- a/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -542,6 +542,7 @@ elytron.ldap-realm.identity-mapping.to=The name of the identity attribute mapped
 elytron.ldap-realm.identity-mapping.filter=The filter to use to obtain the values for a specific attribute.
 elytron.ldap-realm.identity-mapping.filter-base-dn=The name of the context where the filter should be performed.
 elytron.ldap-realm.identity-mapping.as-rdn=The RDN key to use as the value for an attribute, in case the value in its raw form is in X.500 format.
+elytron.ldap-realm.identity-mapping.filter-name=The LDAP filter for getting identity by name.
 elytron.ldap-realm.identity-mapping.iterator-filter=The LDAP filter for iterating over identities of the realm.
 elytron.ldap-realm.identity-mapping.new-identity-parent-dn=The DN of parent of newly created identities. Required for modifiability of the realm.
 elytron.ldap-realm.identity-mapping.new-identity-attributes=The attributes of newly created identities. Required for modifiability of the realm.

--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -985,6 +985,14 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="filter-name" type="xs:string" use="optional" default="(rdn-identifier={0})">
+            <xs:annotation>
+                <xs:documentation>
+                    The LDAP filter for getting identity by name.
+                    The string "{0}" will by replaced by searched identity name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="iterator-filter" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>

--- a/src/test/resources/org/wildfly/extension/elytron/ldap.xml
+++ b/src/test/resources/org/wildfly/extension/elytron/ldap.xml
@@ -8,7 +8,7 @@
 
     <security-realms>
         <ldap-realm name="LdapRealm" direct-verification="false" dir-context="DirContextSsl">
-            <identity-mapping rdn-identifier="uid" search-base-dn="dc=elytron,dc=wildfly,dc=org" use-recursive-search="true" iterator-filter="(uid=*)" new-identity-parent-dn="dc=elytron,dc=wildfly,dc=org">
+            <identity-mapping rdn-identifier="uid" search-base-dn="dc=elytron,dc=wildfly,dc=org" use-recursive-search="true" filter-name="(uid={0})" iterator-filter="(uid=*)" new-identity-parent-dn="dc=elytron,dc=wildfly,dc=org">
                 <attribute-mapping>
                     <attribute from="uid" to="userName"/>
                     <attribute from="cn" to="firstName"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7320

Related to https://github.com/wildfly-security/wildfly-elytron/pull/510

Added filter-name similar to filter-alias in LdapKeyStore. Required to support referrals:
`filter-name="(|(uid={0})(objectclass=referral))"`