### PR TITLE
[WFLY-7288] Elytron - inconsistency between DMR and XSD representation of ldap-realm

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/LdapRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/LdapRealmDefinition.java
@@ -125,7 +125,7 @@ class LdapRealmDefinition extends SimpleResourceDefinition {
 
     static class UserPasswordCredentialMappingObjectDefinition implements CredentialMappingObjectDefinition {
 
-        static final SimpleAttributeDefinition FROM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.FROM, ModelType.STRING, true)
+        static final SimpleAttributeDefinition FROM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.FROM, ModelType.STRING, false)
                 .setAllowExpression(true)
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                 .build();
@@ -236,7 +236,7 @@ class LdapRealmDefinition extends SimpleResourceDefinition {
     }
 
     static class NewIdentityAttributeObjectDefinition {
-        static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.NAME, ModelType.STRING, true)
+        static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.NAME, ModelType.STRING, false)
                 .setAllowExpression(true)
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                 .build();


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-7288

Note: All attributes (algorithm-from, hash-from, seed-from, sequence-from) from otp-credential-mapper are already "nillable" => false and no changes are needed. 
