### PR TITLE
[WFLY-7285] Elytron - inconsistency between DMR and XSD representation of simple-permission-mapper

### DIFF
--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -1639,10 +1639,10 @@
         <xs:complexContent>
             <xs:extension base="permissionMapperType">
                 <xs:sequence>
-                    <xs:element name="permission-mapping" maxOccurs="unbounded">
+                    <xs:element name="permission-mapping" minOccurs="0" maxOccurs="unbounded">
                         <xs:complexType>
                             <xs:sequence>
-                                <xs:element name="permission" maxOccurs="unbounded">
+                                <xs:element name="permission" minOccurs="0" maxOccurs="unbounded">
                                     <xs:complexType>
                                         <xs:attribute name="class-name" type="xs:string" use="required">
                                             <xs:annotation>


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-7285
