### PR TITLE
[WFLY-7473] dir-context - adding connection-timeout, read-timeout

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -83,6 +83,7 @@ interface ElytronDescriptionConstants {
     String CONFIGURATION = "configuration";
     String CONFIGURATION_FILE = "configuration-file";
     String CONFIGURATION_PROPERTIES = "configuration-properties";
+    String CONNECTION_TIMEOUT = "connection-timeout";
     String CONSTANT = "constant";
     String CONSTANT_NAME_REWRITER = "constant-name-rewriter";
     String CONSTANT_PERMISSION_MAPPER = "constant-permission-mapper";
@@ -281,6 +282,7 @@ interface ElytronDescriptionConstants {
 
     String RDN_IDENTIFIER = "rdn-identifier";
     String READ_IDENTITY = "read-identity";
+    String READ_TIMEOUT = "read-timeout";
     String REALM = "realm";
     String REALM_MAP = "realm-map";
     String REALM_MAPPER = "realm-mapper";

--- a/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1070,3 +1070,5 @@ elytron.dir-context.credential=The credential to authenticate and connect to the
 elytron.dir-context.enable-connection-pooling=Indicates if connection pooling is enabled.
 elytron.dir-context.referral-mode=If referrals should be followed.
 elytron.dir-context.ssl-context=The name of ssl-context used to secure connection to the LDAP server.
+elytron.dir-context.connection-timeout=The timeout for connecting to the LDAP server in miliseconds.
+elytron.dir-context.read-timeout=The read timeout for an LDAP operation in miliseconds.

--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -1030,6 +1030,20 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="connection-timeout" type="xs:integer" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The timeout for connecting to the LDAP server in miliseconds.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="read-timeout" type="xs:integer" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The read timeout for an LDAP operation in miliseconds.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="identityMappingType">

--- a/src/test/resources/org/wildfly/extension/elytron/ldap.xml
+++ b/src/test/resources/org/wildfly/extension/elytron/ldap.xml
@@ -44,7 +44,7 @@
    </tls>
    <dir-contexts>
       <dir-context authentication-level="none" name="DirContextInsecure" url="ldap://localhost:11391/"/>
-      <dir-context credential="serverPassword" name="DirContextSsl" principal="uid=server,dc=users,dc=elytron,dc=wildfly,dc=org" referral-mode="follow" ssl-context="LdapSslContext" url="ldaps://localhost:11391/"/>
+      <dir-context credential="serverPassword" name="DirContextSsl" principal="uid=server,dc=users,dc=elytron,dc=wildfly,dc=org" referral-mode="follow" ssl-context="LdapSslContext" url="ldaps://localhost:11391/" connection-timeout="2000" read-timeout="3000"/>
    </dir-contexts>
 
 </subsystem>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7473
(no wildfly-elytron dependency)
* dir-context - adding connection-timeout, read-timeout
* refactoring of DirContextParser to use PersistentResourceXMLDescription