### PR TITLE
[WFLY-7146](reopened) Elytron, regex-name-validating-rewriter - 'match' attribute required and unclear description

### DIFF
--- a/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -238,7 +238,7 @@ elytron.regex-name-validating-rewriter.add=The add operation for the name rewrit
 elytron.regex-name-validating-rewriter.remove=The remove operation for the name rewriter.
 # Attributes
 elytron.regex-name-validating-rewriter.pattern=The regular expression to use for the name validation.
-elytron.regex-name-validating-rewriter.match=If the name must match the pattern. Otherwise the name must not match the pattern.
+elytron.regex-name-validating-rewriter.match=If set to true, the name must match the given pattern to make validation successful. If set to false, the name must not match the given pattern to make validation successful.
 
 ######################
 # Permission Mappers #

--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -1444,7 +1444,8 @@
                     default="true">
                     <xs:annotation>
                         <xs:documentation>
-                            If the name must match the pattern. Otherwise the name must not match the pattern.
+                            If set to true, the name must match the given pattern to make validation successful. 
+                            If set to false, the name must not match the given pattern to make validation successful.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-7146 (reopened)
