### PR TITLE
[WFLY-7491] concatenating-principal-decoder - joiner optional

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/MapperParser.java
+++ b/src/main/java/org/wildfly/extension/elytron/MapperParser.java
@@ -722,7 +722,7 @@ class MapperParser {
         ModelNode addPrincipalDecoder = new ModelNode();
         addPrincipalDecoder.get(OP).set(ADD);
 
-        Set<String> requiredAttributes = new HashSet<>(Arrays.asList(new String[] { NAME, JOINER }));
+        Set<String> requiredAttributes = new HashSet<>(Arrays.asList(new String[] { NAME }));
 
         String name = null;
 

--- a/src/main/java/org/wildfly/extension/elytron/PrincipalDecoderDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/PrincipalDecoderDefinitions.java
@@ -66,7 +66,7 @@ class PrincipalDecoderDefinitions {
 
     static final SimpleAttributeDefinition JOINER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.JOINER, ModelType.STRING, true)
         .setAllowExpression(true)
-        .setMinSize(1)
+        .setMinSize(0)
         .setDefaultValue(new ModelNode("."))
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
         .build();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7491

* removed from required in parser
* allowed zero-length (blank delimiter) (applied to x500-attribute-principal-decoder too)