### PR TITLE
[WFLY-7176] x500-attribute-principal-decoder - names instead of OIDs

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -303,6 +303,7 @@ interface ElytronDescriptionConstants {
     String REQUEST_LIFETIME = "request-lifetime";
     String REQUIRED = "required";
     String REQUIRED_OIDS = "required-oids";
+    String REQUIRED_ATTRIBUTES = "required-attributes";
     String REVERSE = "reverse";
     String RIGHT = "right";
     String ROLE_DECODER = "role-decoder";

--- a/src/main/java/org/wildfly/extension/elytron/MapperParser.java
+++ b/src/main/java/org/wildfly/extension/elytron/MapperParser.java
@@ -37,6 +37,7 @@ import static org.wildfly.extension.elytron.ElytronDescriptionConstants.AGGREGAT
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.AGGREGATE_PRINCIPAL_TRANSFORMER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.AGGREGATE_ROLE_MAPPER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.ATTRIBUTE;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.ATTRIBUTE_NAME;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CHAINED_PRINCIPAL_TRANSFORMER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CLASS_NAME;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CONCATENATING_PRINCIPAL_DECODER;
@@ -85,6 +86,7 @@ import static org.wildfly.extension.elytron.ElytronDescriptionConstants.REGEX_PR
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.REGEX_VALIDATING_PRINCIPAL_TRANSFORMER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.REPLACEMENT;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.REPLACE_ALL;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.REQUIRED_ATTRIBUTES;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.REQUIRED_OIDS;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.REVERSE;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.RIGHT;
@@ -581,7 +583,7 @@ class MapperParser {
         ModelNode addPrincipalDecoder = new ModelNode();
         addPrincipalDecoder.get(OP).set(ADD);
 
-        Set<String> requiredAttributes = new HashSet<String>(Arrays.asList(new String[] { NAME, OID }));
+        Set<String> requiredAttributes = new HashSet<String>(Arrays.asList(new String[] { NAME }));
 
         String name = null;
 
@@ -600,6 +602,9 @@ class MapperParser {
                     case OID:
                         PrincipalDecoderDefinitions.OID.parseAndSetParameter(value, addPrincipalDecoder, reader);
                         break;
+                    case ATTRIBUTE_NAME:
+                        PrincipalDecoderDefinitions.ATTRIBUTE_NAME.parseAndSetParameter(value, addPrincipalDecoder, reader);
+                        break;
                     case JOINER:
                         PrincipalDecoderDefinitions.JOINER.parseAndSetParameter(value, addPrincipalDecoder, reader);
                         break;
@@ -615,6 +620,11 @@ class MapperParser {
                     case REQUIRED_OIDS:
                         for (String requiredOid : reader.getListAttributeValue(i)) {
                             PrincipalDecoderDefinitions.REQUIRED_OIDS.parseAndAddParameterElement(requiredOid, addPrincipalDecoder, reader);
+                        }
+                        break;
+                    case REQUIRED_ATTRIBUTES:
+                        for (String requiredOid : reader.getListAttributeValue(i)) {
+                            PrincipalDecoderDefinitions.REQUIRED_ATTRIBUTES.parseAndAddParameterElement(requiredOid, addPrincipalDecoder, reader);
                         }
                         break;
                     default:
@@ -1506,11 +1516,13 @@ class MapperParser {
                 writer.writeStartElement(X500_ATTRIBUTE_PRINCIPAL_DECODER);
                 writer.writeAttribute(NAME, name);
                 PrincipalDecoderDefinitions.OID.marshallAsAttribute(principalDecoder, writer);
+                PrincipalDecoderDefinitions.ATTRIBUTE_NAME.marshallAsAttribute(principalDecoder, writer);
                 PrincipalDecoderDefinitions.JOINER.marshallAsAttribute(principalDecoder, writer);
                 PrincipalDecoderDefinitions.START_SEGMENT.marshallAsAttribute(principalDecoder, writer);
                 PrincipalDecoderDefinitions.MAXIMUM_SEGMENTS.marshallAsAttribute(principalDecoder, writer);
                 PrincipalDecoderDefinitions.REVERSE.marshallAsAttribute(principalDecoder, writer);
                 PrincipalDecoderDefinitions.REQUIRED_OIDS.getAttributeMarshaller().marshallAsAttribute(PrincipalDecoderDefinitions.REQUIRED_OIDS, principalDecoder, false, writer);
+                PrincipalDecoderDefinitions.REQUIRED_ATTRIBUTES.getAttributeMarshaller().marshallAsAttribute(PrincipalDecoderDefinitions.REQUIRED_ATTRIBUTES, principalDecoder, false, writer);
                 writer.writeEndElement();
             }
 

--- a/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -262,6 +262,12 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 26, value = "trusted-security-domains cannot contain the security-domain \"%s\" itself")
     OperationFailedException trustedDomainsCannotContainDomainItself(String domain);
 
+    @Message(id = 27, value = "Unable to obtain OID for X.500 attribute '%s'")
+    OperationFailedException unableToObtainOidForX500Attribute(String attribute);
+
+    @Message(id = 28, value = "The X.500 attribute must be defined by name or by OID")
+    OperationFailedException x500AttributeMustBeDefined();
+
     // CREDENTIAL_STORE section
     @Message(id = 909, value = "Credential store '%s' does not support given credential store entry type '%s'")
     IllegalArgumentException credentialStoreEntryTypeNotSupported(String credentialStoreName, String entryType);

--- a/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -272,17 +272,19 @@ elytron.custom-principal-decoder.module=Name of the module to use to load the pr
 elytron.custom-principal-decoder.class-name=Fully qualified class name of the principal decoder
 elytron.custom-principal-decoder.configuration=The optional kay/value configuration for the principal decoder
 
-elytron.x500-attribute-principal-decoder=Definition of a X500 attribute based principal decoder
+elytron.x500-attribute-principal-decoder=Definition of a X.500 attribute based principal decoder
 # Operations
 elytron.x500-attribute-principal-decoder.add=Add operation for the principal decoder
 elytron.x500-attribute-principal-decoder.remove=Remove operation for the principal decoder
 #Attributes
-elytron.x500-attribute-principal-decoder.oid=The OID of the attribute to map
+elytron.x500-attribute-principal-decoder.oid=The OID of the X.500 attribute to map (can be defined using attribute name instead)
+elytron.x500-attribute-principal-decoder.attribute-name=The name of the X.500 attribute to map (can be defined using OID instead)
 elytron.x500-attribute-principal-decoder.joiner=The joining string
 elytron.x500-attribute-principal-decoder.start-segment=The 0-based starting occurrence of the attribute to map
 elytron.x500-attribute-principal-decoder.maximum-segments=The maximum number of occurrences of the attribute to map
 elytron.x500-attribute-principal-decoder.reverse=When set to 'true', the attribute values will be processed and returned in reverse order
 elytron.x500-attribute-principal-decoder.required-oids=The OIDs of the attributes that must be present in the principal
+elytron.x500-attribute-principal-decoder.required-attributes=The attributes names of the attributes that must be present in the principal
 
 ##########################
 # Principal Transformers #

--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -1830,13 +1830,22 @@
         </xs:annotation>
         <xs:complexContent>
             <xs:extension base="principalDecoderType">
-                <xs:attribute name="oid" type="xs:string" use="required">
+                <xs:attribute name="oid" type="xs:string">
                     <xs:annotation>
                         <xs:documentation>
                             The oid of the attribute to map.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="attribute-name" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The oid of the attribute to map.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <!-- exactly one of [oid, attribute-name] must be defined -->
+                <!--<xs:assert test="(@oid and not(@attribute-name)) or (not(@oid) and @attribute-name)"/>--><!-- require XSD 1.1 -->
                 <xs:attribute name="joiner" type="xs:string" default=".">
                     <xs:annotation>
                         <xs:documentation>
@@ -1869,6 +1878,13 @@
                     <xs:annotation>
                         <xs:documentation>
                             The OIDs of the attributes that must be present in the principal.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="required-attributes" type="stringListType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The attribute names of the attributes that must be present in the principal.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>

--- a/src/test/resources/org/wildfly/extension/elytron/domain-test.xml
+++ b/src/test/resources/org/wildfly/extension/elytron/domain-test.xml
@@ -51,9 +51,9 @@
             <principal-decoder name="MyDcDecoder"/>
         </concatenating-principal-decoder>
         <x500-attribute-principal-decoder joiner="," maximum-segments="6" name="MyX500PrincipalDecoder" oid="2.5.4.3"/>
-        <x500-attribute-principal-decoder joiner="," maximum-segments="1" name="MyX500PrincipalDecoderTwo" oid="2.5.4.3" required-oids="2.5.4.3 2.5.4.11" reverse="true"
+        <x500-attribute-principal-decoder joiner="," maximum-segments="1" name="MyX500PrincipalDecoderTwo" oid="2.5.4.3" required-oids="2.5.4.3 2.5.4.11" required-attributes="cN" reverse="true"
                                           start-segment="2"/>
-        <x500-attribute-principal-decoder maximum-segments="1" name="MyCnDecoder" oid="2.5.4.3" start-segment="1"/>
+        <x500-attribute-principal-decoder maximum-segments="1" name="MyCnDecoder" attribute-name="Cn" start-segment="1"/>
         <x500-attribute-principal-decoder name="MyDcDecoder" oid="0.9.2342.19200300.100.1.25"/>
         <regex-principal-transformer name="NameRewriterXY" pattern="x(.*)" replacement="y$1"/>
         <regex-principal-transformer name="NameRewriterYU" pattern="y(.*)" replacement="u$1"/>


### PR DESCRIPTION
Depends on https://github.com/wildfly-security/wildfly-elytron/pull/550
https://issues.jboss.org/browse/WFLY-7176

Note: OID+ATTRIBUTE_NAME should be set as require when will be WFCORE-1556 resolved:
http://wildfly-development.1055759.n5.nabble.com/Fixing-handling-of-required-attributes-with-alternatives-td5717450.html

UPDATE: or do you think it woul be better one attribute "attribute", which would combine OID+ATTRIBUTE_NAME ?