### PR TITLE
[WFLY-7175] ssl-session resource flattening and fixes

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/CertificateChainAttributeDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/CertificateChainAttributeDefinitions.java
@@ -120,35 +120,21 @@ class CertificateChainAttributeDefinitions {
         certificateModel.get(ElytronDescriptionConstants.TYPE).set(certificate.getType());
 
         PublicKey publicKey = certificate.getPublicKey();
-        ModelNode publicKeyModel = new ModelNode();
-        publicKeyModel.get(ElytronDescriptionConstants.ALGORITHM).set(publicKey.getAlgorithm());
-        publicKeyModel.get(ElytronDescriptionConstants.FORMAT).set(publicKey.getFormat());
-        publicKeyModel.get(ElytronDescriptionConstants.ENCODED).set(encodedHexString(publicKey.getEncoded()));
-        certificateModel.get(ElytronDescriptionConstants.PUBLIC_KEY).set(publicKeyModel);
+        certificateModel.get(ElytronDescriptionConstants.ALGORITHM).set(publicKey.getAlgorithm());
+        certificateModel.get(ElytronDescriptionConstants.FORMAT).set(publicKey.getFormat());
+        certificateModel.get(ElytronDescriptionConstants.PUBLIC_KEY).set(encodedHexString(publicKey.getEncoded()));
 
-        ModelNode fingerPrintsModel = new ModelNode();
         byte[] encodedCertificate = certificate.getEncoded();
-
-        ModelNode sha1 = new ModelNode();
-        sha1.get(ElytronDescriptionConstants.ALGORITHM).set(SHA_1);
-        sha1.get(ElytronDescriptionConstants.VALUE).set(encodedHexString(digest(SHA_1, encodedCertificate)));
-        fingerPrintsModel.add(sha1);
-
-        ModelNode sha256 = new ModelNode();
-        sha256.get(ElytronDescriptionConstants.ALGORITHM).set(SHA_256);
-        sha256.get(ElytronDescriptionConstants.VALUE).set(encodedHexString(digest(SHA_256, encodedCertificate)));
-        fingerPrintsModel.add(sha256);
-
-        certificateModel.get(ElytronDescriptionConstants.FINGER_PRINTS).set(fingerPrintsModel);
-
+        certificateModel.get(ElytronDescriptionConstants.SHA_1_DIGEST).set(encodedHexString(digest(SHA_1, encodedCertificate)));
+        certificateModel.get(ElytronDescriptionConstants.SHA_256_DIGEST).set(encodedHexString(digest(SHA_256, encodedCertificate)));
         certificateModel.get(ElytronDescriptionConstants.ENCODED).set(encodedHexString(encodedCertificate));
 
         if (certificate instanceof X509Certificate) {
-            writeCertificate(certificateModel, (X509Certificate) certificate);
+            writeX509Certificate(certificateModel, (X509Certificate) certificate);
         }
     }
 
-    private static void writeCertificate(final ModelNode certificateModel, final X509Certificate certificate) throws CertificateEncodingException, NoSuchAlgorithmException {
+    private static void writeX509Certificate(final ModelNode certificateModel, final X509Certificate certificate) throws CertificateEncodingException, NoSuchAlgorithmException {
         SimpleDateFormat sdf = new SimpleDateFormat(ISO_8601_FORMAT);
 
         certificateModel.get(ElytronDescriptionConstants.SUBJECT).set(certificate.getSubjectX500Principal().getName());

--- a/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -339,6 +339,8 @@ interface ElytronDescriptionConstants {
     String SERVICE_LOADER_SASL_SERVER_FACTORY = "service-loader-sasl-server-factory";
     String SERVICES = "services";
     String SEQUENCE_FROM = "sequence-from";
+    String SHA_1_DIGEST = "sha-1-digest";
+    String SHA_256_DIGEST = "sha-256-digest";
     String SIGNATURE = "signature";
     String SIGNATURE_ALGORITHM = "signature-algorithm";
     String SIMPLE_DIGEST = "simple-digest";


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7175
* CertificateChainAttributeDefinitions: flattened model as requested by WFLY-7175
* Other: Fixes of ssl-session resource (information about side (client/server) need to be passed to SSLSession resource)
 * covered by tests