### PR TITLE
[WFLY-7589] Wrong description for injecting the same realm to Elytron security-domain in CLI

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/DomainService.java
+++ b/src/main/java/org/wildfly/extension/elytron/DomainService.java
@@ -85,7 +85,7 @@ class DomainService implements Service<SecurityDomain> {
 
     RealmDependency createRealmDependency(final String realmName) throws OperationFailedException {
         if (realms.containsKey(realmName)) {
-            throw ROOT_LOGGER.duplicateRealmInjection(name, realmName);
+            throw ROOT_LOGGER.duplicateRealmInjection(realmName, name);
         }
 
         RealmDependency realmDependency = new RealmDependency();


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-7589
