### PR TITLE
Issue #285 use Credential Store Client Util from Credential Store resource definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <version.elytron>1.1.0.Beta16</version.elytron>
 
-        <version.wildfly.core>3.0.0.Alpha12</version.wildfly.core>
+        <version.wildfly.core>3.0.0.Alpha13</version.wildfly.core>
 
         <version.org.jboss.jboss-dmr>1.4.0.Beta1</version.org.jboss.jboss-dmr>
         <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>

--- a/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -33,7 +33,7 @@ import static org.wildfly.extension.elytron.Capabilities.TRUST_MANAGERS_RUNTIME_
 import static org.wildfly.extension.elytron.ElytronExtension.asStringIfDefined;
 import static org.wildfly.extension.elytron.ElytronExtension.getRequiredService;
 import static org.wildfly.extension.elytron.KeyStoreDefinition.CREDENTIAL_REFERENCE;
-import static org.wildfly.extension.elytron.KeyStoreDefinition.CREDENTIAL_STORE_CLIENT_SERVICE_UTIL;
+import static org.wildfly.extension.elytron.CredentialStoreResourceDefinition.CREDENTIAL_STORE_CLIENT_UTIL;
 import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.ROOT_LOGGER;
 
 import java.security.GeneralSecurityException;
@@ -296,7 +296,7 @@ class SSLDefinitions {
                 if (credentialReference.getAlias() != null) {
                     String credentialStoreClientCapabilityName = RuntimeCapability.buildDynamicCapabilityName(CREDENTIAL_STORE_CLIENT_CAPABILITY, credentialReference.getCredentialStoreName());
                     ServiceName credentialStoreClientServiceName = context.getCapabilityServiceName(credentialStoreClientCapabilityName, CredentialStoreClient.class);
-                    CREDENTIAL_STORE_CLIENT_SERVICE_UTIL.addInjection(serviceBuilder, credentialStoreClientInjector, credentialStoreClientServiceName);
+                    CREDENTIAL_STORE_CLIENT_UTIL.addInjection(serviceBuilder, credentialStoreClientInjector, credentialStoreClientServiceName);
                 }
 
                 return () -> {


### PR DESCRIPTION
There is wildfly-core version bump included as I need the newest API for CredentialReference.
resolves: https://github.com/wildfly-security/elytron-subsystem/issues/285