### PR TITLE
WFLY-7665: fix writeAttribute definition for LDAP keystore

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/LdapKeyStoreDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/LdapKeyStoreDefinition.java
@@ -351,7 +351,7 @@ final class LdapKeyStoreDefinition extends SimpleResourceDefinition {
     private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
 
         WriteAttributeHandler() {
-            super(ElytronDescriptionConstants.KEY_STORE, CONFIG_ATTRIBUTES);
+            super(ElytronDescriptionConstants.LDAP_KEY_STORE, CONFIG_ATTRIBUTES);
         }
 
         @Override


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-7665