### PR TITLE
[WFLY-7653] Validate session-timeout and maximum-session-cache-size to be non-negative

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -72,6 +72,7 @@ import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.operations.validation.AllowedValuesValidator;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -181,12 +182,14 @@ class SSLDefinitions {
     static final SimpleAttributeDefinition MAXIMUM_SESSION_CACHE_SIZE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.MAXIMUM_SESSION_CACHE_SIZE, ModelType.INT, true)
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(0))
+            .setValidator(new IntRangeValidator(0))
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
     static final SimpleAttributeDefinition SESSION_TIMEOUT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SESSION_TIMEOUT, ModelType.INT, true)
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(0))
+            .setValidator(new IntRangeValidator(0))
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 

--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -3352,14 +3352,14 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="maximum-session-cache-size" type="xs:int" default="0">
+        <xs:attribute name="maximum-session-cache-size" type="xs:nonNegativeInteger" default="0">
             <xs:annotation>
                 <xs:documentation>
                     The maximum number of SSL sessions in the cache. The default value zero means there is no limit.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="session-timeout" type="xs:int" default="0">
+        <xs:attribute name="session-timeout" type="xs:nonNegativeInteger" default="0">
             <xs:annotation>
                 <xs:documentation>
                     The timeout for SSL sessions, in seconds. The default value zero means there is no limit.


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-7653
