### PR TITLE
[WFLY-7829] Coverity: wrong condition in ProviderLoaderService.unregisterProviders (Elytron subsystem)

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/ProviderLoaderService.java
+++ b/src/main/java/org/wildfly/extension/elytron/ProviderLoaderService.java
@@ -249,7 +249,7 @@ class ProviderLoaderService implements Service<Provider[]> {
     }
 
     private void unregisterProviders() {
-        for (int i = providers.length - 1; i < 0; i--) {
+        for (int i = providers.length - 1; i >= 0; i--) {
             Security.removeProvider(providers[i].getName());
         }
     }


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-7829
