### PR TITLE
Resolve deprecated API call, build warnings

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/AggregateComponentDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/AggregateComponentDefinition.java
@@ -82,7 +82,7 @@ class AggregateComponentDefinition<T> extends SimpleResourceDefinition {
         String capabilityName = runtimeCapability.getName();
         StringListAttributeDefinition aggregateReferences = new StringListAttributeDefinition.Builder(referencesName)
             .setMinSize(2)
-            .setAllowNull(false)
+            .setRequired(true)
             .setCapabilityReference(capabilityName, capabilityName, true)
             .build();
 

--- a/src/main/java/org/wildfly/extension/elytron/AuthenticationClientDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/AuthenticationClientDefinitions.java
@@ -133,7 +133,7 @@ class AuthenticationClientDefinitions {
 
     static final StringListAttributeDefinition ALLOW_SASL_MECHANISMS = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.ALLOW_SASL_MECHANISMS)
             .setMinSize(0)
-            .setAllowNull(true)
+            .setRequired(false)
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .setAlternatives(ElytronDescriptionConstants.ALLOW_ALL_MECHANISMS)
@@ -141,7 +141,7 @@ class AuthenticationClientDefinitions {
 
     static final StringListAttributeDefinition FORBID_SASL_MECHANISMS = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.FORBID_SASL_MECHANISMS)
             .setMinSize(0)
-            .setAllowNull(true)
+            .setRequired(false)
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();

--- a/src/main/java/org/wildfly/extension/elytron/CertificateChainAttributeDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/CertificateChainAttributeDefinitions.java
@@ -71,35 +71,35 @@ class CertificateChainAttributeDefinitions {
      */
 
     private static final SimpleAttributeDefinition SUBJECT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SUBJECT, ModelType.STRING)
-        .setAllowNull(true)
+        .setRequired(false)
         .build();
 
     private static final SimpleAttributeDefinition ISSUER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ISSUER, ModelType.STRING)
-        .setAllowNull(true)
+        .setRequired(false)
         .build();
 
     private static final SimpleAttributeDefinition NOT_AFTER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.NOT_AFTER, ModelType.STRING)
-        .setAllowNull(true)
+        .setRequired(false)
         .build();
 
     private static final SimpleAttributeDefinition NOT_BEFORE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.NOT_BEFORE, ModelType.STRING)
-        .setAllowNull(true)
+        .setRequired(false)
         .build();
 
     private static final SimpleAttributeDefinition SERIAL_NUMBER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SERIAL_NUMBER, ModelType.STRING)
-        .setAllowNull(true)
+        .setRequired(false)
         .build();
 
     private static final SimpleAttributeDefinition SIGNATURE_ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SIGNATURE_ALGORITHM, ModelType.STRING)
-        .setAllowNull(true)
+        .setRequired(false)
         .build();
 
     private static final SimpleAttributeDefinition SIGNATURE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SIGNATURE, ModelType.STRING)
-        .setAllowNull(true)
+        .setRequired(false)
         .build();
 
     private static final SimpleAttributeDefinition VERSION = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.VERSION, ModelType.STRING)
-        .setAllowNull(true)
+        .setRequired(false)
         .build();
 
     // TODO - Consider adding some of the more detailed fields from X509Certificate

--- a/src/main/java/org/wildfly/extension/elytron/ClassLoadingAttributeDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/ClassLoadingAttributeDefinitions.java
@@ -47,7 +47,7 @@ class ClassLoadingAttributeDefinitions {
     static final StringListAttributeDefinition CLASS_NAMES = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.CLASS_NAMES)
         .setAttributeGroup(ElytronDescriptionConstants.CLASS_LOADING)
         .setAllowExpression(false)
-        .setAllowNull(true)
+        .setRequired(false)
         .build();
 
     static ClassLoader resolveClassLoader(String module) throws ModuleLoadException {

--- a/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
@@ -272,7 +272,7 @@ final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
         @Override
         protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
             ServiceName credentialStoreServiceName = CREDENTIAL_STORE_UTIL.serviceName(operation);
-            ServiceController<CredentialStore> credentialStoreServiceController = (ServiceController<CredentialStore>) context.getServiceRegistry(writeAccess).getRequiredService(credentialStoreServiceName);
+            ServiceController<?> credentialStoreServiceController = context.getServiceRegistry(writeAccess).getRequiredService(credentialStoreServiceName);
             State serviceState;
             if ((serviceState = credentialStoreServiceController.getState()) != State.UP) {
                 if (serviceMustBeUp) {

--- a/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
@@ -148,7 +148,7 @@ class DomainDefinition extends SimpleResourceDefinition {
         .build();
 
     static final StringListAttributeDefinition TRUSTED_SECURITY_DOMAINS = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.TRUSTED_SECURITY_DOMAINS)
-            .setAllowNull(true)
+            .setRequired(false)
             .setMinSize(1)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)

--- a/src/main/java/org/wildfly/extension/elytron/FileSystemRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/FileSystemRealmDefinition.java
@@ -66,7 +66,7 @@ class FileSystemRealmDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition PATH =
             new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PATH, FileAttributeDefinitions.PATH)
                     .setAttributeGroup(ElytronDescriptionConstants.FILE)
-                    .setAllowNull(false)
+                    .setRequired(true)
                     .build();
 
     static final SimpleAttributeDefinition RELATIVE_TO =

--- a/src/main/java/org/wildfly/extension/elytron/KerberosSecurityFactoryDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/KerberosSecurityFactoryDefinition.java
@@ -59,7 +59,7 @@ import org.wildfly.security.auth.util.GSSCredentialSecurityFactory;
 class KerberosSecurityFactoryDefinition {
 
     static final SimpleAttributeDefinition PATH = new SimpleAttributeDefinitionBuilder(FileAttributeDefinitions.PATH)
-        .setAllowNull(false)
+        .setRequired(true)
         .build();
 
     static final SimpleAttributeDefinition PRINCIPAL = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PRINCIPAL, ModelType.STRING, false)
@@ -94,7 +94,7 @@ class KerberosSecurityFactoryDefinition {
 
     static final StringListAttributeDefinition MECHANISM_OIDS = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.MECHANISM_OIDS)
         .setAllowExpression(true)
-        .setAllowNull(false)
+        .setRequired(true)
         .setMinSize(1)
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
         .build();

--- a/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
@@ -96,13 +96,13 @@ class PermissionMapperDefinitions {
 
     static final StringListAttributeDefinition PRINCIPALS = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.PRINCIPALS)
             .setAllowExpression(true)
-            .setAllowNull(true)
+            .setRequired(false)
             .setMinSize(1)
             .build();
 
     static final StringListAttributeDefinition ROLES = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.ROLES)
             .setAllowExpression(true)
-            .setAllowNull(true)
+            .setRequired(false)
             .setMinSize(1)
             .build();
 

--- a/src/main/java/org/wildfly/extension/elytron/PrincipalDecoderDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/PrincipalDecoderDefinitions.java
@@ -101,14 +101,14 @@ class PrincipalDecoderDefinitions {
         .build();
 
     static final StringListAttributeDefinition REQUIRED_OIDS = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.REQUIRED_OIDS)
-        .setAllowNull(true)
+        .setRequired(false)
         .setAllowExpression(true)
         .setMinSize(1)
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
         .build();
 
     static final StringListAttributeDefinition REQUIRED_ATTRIBUTES = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.REQUIRED_ATTRIBUTES)
-        .setAllowNull(true)
+        .setRequired(false)
         .setMinSize(1)
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
         .build();
@@ -121,7 +121,7 @@ class PrincipalDecoderDefinitions {
 
     static final StringListAttributeDefinition PRINCIPAL_DECODERS = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.PRINCIPAL_DECODERS)
         .setMinSize(2)
-        .setAllowNull(false)
+        .setRequired(true)
         .setCapabilityReference(PRINCIPAL_DECODER_RUNTIME_CAPABILITY.getName(), PRINCIPAL_DECODER_RUNTIME_CAPABILITY.getName(), true)
         .build();
 

--- a/src/main/java/org/wildfly/extension/elytron/PropertiesRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/PropertiesRealmDefinition.java
@@ -83,7 +83,7 @@ import org.wildfly.security.evidence.Evidence;
 class PropertiesRealmDefinition extends TrivialResourceDefinition {
 
     static final SimpleAttributeDefinition PATH = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PATH, FileAttributeDefinitions.PATH)
-            .setAllowNull(false)
+            .setRequired(true)
             .build();
 
     static final ObjectTypeAttributeDefinition USERS_PROPERTIES = new ObjectTypeAttributeDefinition.Builder(ElytronDescriptionConstants.USERS_PROPERTIES, PATH, RELATIVE_TO)

--- a/src/main/java/org/wildfly/extension/elytron/RealmDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/RealmDefinitions.java
@@ -62,7 +62,7 @@ public class RealmDefinitions {
 
     static final StringListAttributeDefinition ATTRIBUTE_VALUES = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.ATTRIBUTE_VALUES)
             .setMinSize(0)
-            .setAllowNull(true)
+            .setRequired(false)
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();

--- a/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -141,7 +141,7 @@ class SSLDefinitions {
     static final StringListAttributeDefinition PROTOCOLS = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.PROTOCOLS)
             .setAllowExpression(true)
             .setMinSize(1)
-            .setAllowNull(true)
+            .setRequired(false)
             .setAllowedValues(ALLOWED_PROTOCOLS)
             .setValidator(new StringValuesValidator(ALLOWED_PROTOCOLS))
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)

--- a/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
@@ -88,13 +88,13 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
 
         static final StringListAttributeDefinition ISSUER = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.ISSUER)
                 .setAllowExpression(true)
-                .setAllowNull(true)
+                .setRequired(false)
                 .setMinSize(1)
                 .build();
 
         static final StringListAttributeDefinition AUDIENCE = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.AUDIENCE)
                 .setAllowExpression(true)
-                .setAllowNull(true)
+                .setRequired(false)
                 .setMinSize(1)
                 .build();
 
@@ -139,7 +139,7 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                 .build();
 
         static final SimpleAttributeDefinition HOSTNAME_VERIFICATION_POLICY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.HOST_NAME_VERIFICATION_POLICY, ModelType.STRING, true)
-                .setValidator(new EnumValidator(HostnameVerificationPolicy.class, true, true))
+                .setValidator(new EnumValidator<>(HostnameVerificationPolicy.class, true, true))
                 .setAllowExpression(true)
                 .setMinSize(1)
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)


### PR DESCRIPTION
Resolve build warning:
* Type conversions
* setAllowNull() deprecated in controller API replaced by setRequired()