### PR TITLE
Resolves #370 Add support for caching realms

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/CachingRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/CachingRealmDefinition.java
@@ -1,0 +1,194 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.elytron;
+
+import static org.wildfly.extension.elytron.Capabilities.SECURITY_REALM_CAPABILITY;
+import static org.wildfly.extension.elytron.Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY;
+import static org.wildfly.extension.elytron.ElytronDefinition.commonDependencies;
+import static org.wildfly.extension.elytron.ElytronExtension.getRequiredService;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.RestartParentWriteAttributeHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceController.Mode;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.extension.elytron._private.ElytronSubsystemMessages;
+import org.wildfly.security.auth.realm.CacheableSecurityRealm;
+import org.wildfly.security.auth.realm.CachingModifiableSecurityRealm;
+import org.wildfly.security.auth.realm.CachingSecurityRealm;
+import org.wildfly.security.auth.server.ModifiableSecurityRealm;
+import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.cache.LRURealmIdentityCache;
+import org.wildfly.security.cache.RealmIdentityCache;
+
+/**
+ * A {@link ResourceDefinition} for a {@link SecruityRealm} which enables caching to another realm.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+class CachingRealmDefinition extends SimpleResourceDefinition {
+
+    static final ServiceUtil<SecurityRealm> REALM_SERVICE_UTIL = ServiceUtil.newInstance(SECURITY_REALM_RUNTIME_CAPABILITY, ElytronDescriptionConstants.CACHING_REALM, SecurityRealm.class);
+
+    static final SimpleAttributeDefinition REALM_NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.REALM, ModelType.STRING, false)
+            .setMinSize(1)
+            .setCapabilityReference(SECURITY_REALM_CAPABILITY)
+            .build();
+
+    static final SimpleAttributeDefinition MAXIMUM_ENTRIES = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.MAXIMUM_ENTRIES, ModelType.INT, true)
+            .setDefaultValue(new ModelNode(16))
+            .setMinSize(1)
+            .build();
+
+    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {REALM_NAME, MAXIMUM_ENTRIES};
+
+    private static final AbstractAddStepHandler ADD = new RealmAddHandler();
+    private static final OperationStepHandler REMOVE = new TrivialCapabilityServiceRemoveHandler(ADD, SECURITY_REALM_RUNTIME_CAPABILITY);
+
+    CachingRealmDefinition() {
+        super(new Parameters(PathElement.pathElement(ElytronDescriptionConstants.CACHING_REALM), ElytronExtension.getResourceDescriptionResolver(ElytronDescriptionConstants.CACHING_REALM))
+            .setAddHandler(ADD)
+            .setRemoveHandler(REMOVE)
+            .setAddRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+            .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+            .setCapabilities(SECURITY_REALM_RUNTIME_CAPABILITY));
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        WriteAttributeHandler write = new WriteAttributeHandler(ElytronDescriptionConstants.CACHING_REALM);
+        for (AttributeDefinition current : ATTRIBUTES) {
+            resourceRegistration.registerReadWriteAttribute(current, null, write);
+        }
+    }
+
+    @Override
+    public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+        super.registerOperations(resourceRegistration);
+        ClearCacheHandler.register(resourceRegistration, getResourceDescriptionResolver());
+    }
+
+    private static class RealmAddHandler extends BaseAddHandler {
+
+        private RealmAddHandler() {
+            super(SECURITY_REALM_RUNTIME_CAPABILITY, ATTRIBUTES);
+        }
+
+        @Override
+        protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+                throws OperationFailedException {
+            ServiceTarget serviceTarget = context.getServiceTarget();
+            RuntimeCapability<Void> runtimeCapability = SECURITY_REALM_RUNTIME_CAPABILITY.fromBaseCapability(context.getCurrentAddressValue());
+            ServiceName realmName = runtimeCapability.getCapabilityServiceName(SecurityRealm.class);
+            String cacheableRealm = REALM_NAME.resolveModelAttribute(context, model).asString();
+            int maxEntries = MAXIMUM_ENTRIES.resolveModelAttribute(context, model).asInt();
+            InjectedValue<SecurityRealm> cacheableRealmValue = new InjectedValue<>();
+            ServiceBuilder<SecurityRealm> serviceBuilder = serviceTarget.addService(realmName, createService(cacheableRealm, maxEntries, cacheableRealmValue));
+
+            addRealmDependency(context, serviceBuilder, cacheableRealm, cacheableRealmValue);
+            commonDependencies(serviceBuilder).setInitialMode(Mode.ACTIVE).install();
+        }
+
+        private TrivialService<SecurityRealm> createService(String realmName, int maxEntries, InjectedValue<SecurityRealm> injector) {
+            return new TrivialService<>((TrivialService.ValueSupplier<SecurityRealm>) () -> {
+                SecurityRealm securityRealm = injector.getValue();
+
+                if (securityRealm instanceof CacheableSecurityRealm) {
+                    RealmIdentityCache cache = createRealmIdentityCache(maxEntries);
+                    CacheableSecurityRealm cacheableRealm = CacheableSecurityRealm.class.cast(securityRealm);
+
+                    if (securityRealm instanceof ModifiableSecurityRealm) {
+                        return new CachingModifiableSecurityRealm(cacheableRealm, cache);
+                    }
+
+                    return new CachingSecurityRealm(cacheableRealm, cache);
+                }
+
+                throw ElytronSubsystemMessages.ROOT_LOGGER.realmDoesNotSupportCache(realmName);
+            });
+        }
+
+        private LRURealmIdentityCache createRealmIdentityCache(int maxEntries) {
+            return new LRURealmIdentityCache(maxEntries);
+        }
+
+        private void addRealmDependency(OperationContext context, ServiceBuilder<SecurityRealm> serviceBuilder, String realmName, Injector<SecurityRealm> securityRealmInjector) {
+            String runtimeCapability = RuntimeCapability.buildDynamicCapabilityName(SECURITY_REALM_CAPABILITY, realmName);
+            ServiceName realmServiceName = context.getCapabilityServiceName(runtimeCapability, SecurityRealm.class);
+            REALM_SERVICE_UTIL.addInjection(serviceBuilder, securityRealmInjector, realmServiceName);
+        }
+
+    }
+
+    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+
+        WriteAttributeHandler(final String key) {
+            super(key, ATTRIBUTES);
+        }
+
+        @Override
+        protected ServiceName getParentServiceName(PathAddress pathAddress) {
+            return SECURITY_REALM_RUNTIME_CAPABILITY.fromBaseCapability(pathAddress.getLastElement().getValue()).getCapabilityServiceName(SecurityRealm.class);
+        }
+    }
+
+    private static class ClearCacheHandler implements OperationStepHandler {
+
+        static void register(ManagementResourceRegistration resourceRegistration, ResourceDescriptionResolver descriptionResolver) {
+            resourceRegistration.registerOperationHandler(new SimpleOperationDefinition(ElytronDescriptionConstants.CLEAR_CACHE, descriptionResolver), new CachingRealmDefinition.ClearCacheHandler());
+        }
+
+        private ClearCacheHandler() {
+        }
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            context.addStep(operation, (parentContext, parentOperation) -> {
+                ServiceRegistry serviceRegistry = context.getServiceRegistry(false);
+                PathAddress currentAddress = context.getCurrentAddress();
+                RuntimeCapability<Void> runtimeCapability = SECURITY_REALM_RUNTIME_CAPABILITY.fromBaseCapability(currentAddress.getLastElement().getValue());
+                ServiceName realmName = runtimeCapability.getCapabilityServiceName();
+                ServiceController<SecurityRealm> serviceController = getRequiredService(serviceRegistry, realmName, SecurityRealm.class);
+                CachingSecurityRealm securityRealm = CachingSecurityRealm.class.cast(serviceController.getValue());
+                securityRealm.removeAllFromCache();
+            }, OperationContext.Stage.RUNTIME);
+        }
+    }
+}

--- a/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -119,6 +119,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(new TokenRealmDefinition());
         resourceRegistration.registerSubModel(SecurityRealmResourceDecorator.wrap(new LdapRealmDefinition()));
         resourceRegistration.registerSubModel(SecurityRealmResourceDecorator.wrap(new FileSystemRealmDefinition()));
+        resourceRegistration.registerSubModel(new CachingRealmDefinition());
 
         // Security Factories
         resourceRegistration.registerSubModel(new CustomComponentDefinition<CredentialSecurityFactory>(CredentialSecurityFactory.class, ElytronDescriptionConstants.CUSTOM_CREDENTIAL_SECURITY_FACTORY, SECURITY_FACTORY_CREDENTIAL_RUNTIME_CAPABILITY));

--- a/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -67,6 +67,7 @@ interface ElytronDescriptionConstants {
     String BCRYPT = "bcrypt";
     String BCRYPT_MAPPER = "bcrypt-mapper";
 
+    String CACHING_REALM = "caching-realm";
     String CERTIFICATE = "certificate";
     String CERTIFICATE_ATTRIBUTE = "certificate-attribute";
     String CERTIFICATE_CHAIN = "certificate-chain";
@@ -81,6 +82,7 @@ interface ElytronDescriptionConstants {
     String CLASS_NAME = "class-name";
     String CLASS_NAMES = "class-names";
     String CLEAR = "clear";
+    String CLEAR_CACHE = "clear-cache";
     String CLEAR_PASSWORD_MAPPER = "clear-password-mapper";
     String CLIENT_ID = "client-id";
     String CLIENT_SECRET = "client-secret";
@@ -232,6 +234,7 @@ interface ElytronDescriptionConstants {
     String MATCH_RULES = "match-rules";
     String MATCH_URN = "match-urn";
     String MATCH_USER = "match-user";
+    String MAXIMUM_ENTRIES = "maximum-entries";
     String MAXIMUM_SEGMENTS = "maximum-segments";
     String MAXIMUM_SESSION_CACHE_SIZE = "maximum-session-cache-size";
     String MECHANISM = "mechanism";

--- a/src/main/java/org/wildfly/extension/elytron/RealmParser.java
+++ b/src/main/java/org/wildfly/extension/elytron/RealmParser.java
@@ -23,6 +23,7 @@ import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoAttributes;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.AGGREGATE_REALM;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CACHING_REALM;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CUSTOM_MODIFIABLE_REALM;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CUSTOM_REALM;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.FILESYSTEM_REALM;
@@ -88,9 +89,11 @@ class RealmParser {
             .addAttributes(FileSystemRealmDefinition.ATTRIBUTES)
             .setMarshallDefaultValues(true)
             .build();
-
     private final PersistentResourceXMLDescription tokenRealmParser = builder(PathElement.pathElement(ElytronDescriptionConstants.TOKEN_REALM), null)
             .addAttributes(TokenRealmDefinition.ATTRIBUTES)
+            .build();
+    private final PersistentResourceXMLDescription cachingRealmParser = builder(PathElement.pathElement(ElytronDescriptionConstants.CACHING_REALM), null)
+            .addAttributes(CachingRealmDefinition.ATTRIBUTES)
             .build();
 
     /*final PersistentResourceXMLDescription realmParser = builder(PathElement.pathElement(ElytronDescriptionConstants.SECURITY_REALMS, "ignored"), null)
@@ -154,6 +157,9 @@ class RealmParser {
                 case TOKEN_REALM:
                     tokenRealmParser.parse(reader, parentAddress, operations);
                     break;
+                case CACHING_REALM:
+                    cachingRealmParser.parse(reader, parentAddress, operations);
+                    break;
                 default:
                     throw unexpectedElement(reader);
             }
@@ -178,6 +184,7 @@ class RealmParser {
         ldapRealmParser.persist(writer, subsystem);
         fileSystemRealmDescription.persist(writer, subsystem);
         tokenRealmParser.persist(writer, subsystem);
+        cachingRealmParser.persist(writer, subsystem);
 
         writer.writeEndElement();
     }

--- a/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -272,6 +272,9 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 29, value = "Failed to parse URL '%s'")
     OperationFailedException invalidURL(String url, @Cause Exception cause);
 
+    @Message(id = 30, value = "Realm '%s' does not support cache")
+    StartException realmDoesNotSupportCache(String realmName);
+
     // CREDENTIAL_STORE section
     @Message(id = 909, value = "Credential store '%s' does not support given credential store entry type '%s'")
     IllegalArgumentException credentialStoreEntryTypeNotSupported(String credentialStoreName, String entryType);

--- a/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -724,6 +724,16 @@ elytron.modifiable-security-realm.identity.digest.algorithm=The algorithm used t
 elytron.modifiable-security-realm.identity.digest.realm=The realm.
 elytron.modifiable-security-realm.identity.digest.password=The actual password to set.
 
+elytron.caching-realm=A realm definition that enables caching to another security realm. Caching strategy is LRU (Least Recently Used) where least accessed entries are discarded when maximum number of entries is reached.
+# Operations
+elytron.caching-realm.add=The add operation for the security realm.
+elytron.caching-realm.remove=The remove operation for the security realm.
+# Attributes
+elytron.caching-realm.realm=A reference to a cacheable security realm.
+elytron.caching-realm.maximum-entries=The maximum number of entries to keep in the cache.
+elytron.caching-realm.clear-cache=Removes all entries from the cache.
+
+
 #########################
 # SASL Server Factories #
 #########################

--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -607,6 +607,7 @@
             <xs:element name="ldap-realm" type="ldapRealmType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="filesystem-realm" type="fileSystemRealmType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="token-realm" type="tokenRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="caching-realm" type="cachingRealmType" minOccurs="0" maxOccurs="unbounded" />
         </xs:choice>
     </xs:complexType>
 
@@ -645,6 +646,32 @@
                     <xs:annotation>
                         <xs:documentation>
                             The name of the realm to use for the authorization steps (loading of the identity).
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="cachingRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A realm definition that enables caching to another security realm. Caching strategy is LRU (Least Recently Used) where least accessed entries are discarded when maximum number of entries is reached.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:attribute name="realm" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A reference to a cacheable security realm.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="maximum-entries" type="xs:int" use="optional" default="16">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The maximum number of entries to keep in the cache.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>

--- a/src/test/resources/org/wildfly/extension/elytron/security-realms.xml
+++ b/src/test/resources/org/wildfly/extension/elytron/security-realms.xml
@@ -97,6 +97,7 @@
         <token-realm name="OAuth2Realm" principal-claim="sub">
             <oauth2-introspection client-id="a" client-secret="b" introspection-url="https://localhost/token/introspect"/>
         </token-realm>
+        <caching-realm name="CachingRealm" realm="RealmEight" maximum-entries="32"/>
     </security-realms>
     <!-- Needed by the filesystem-realms -->
     <mappers>


### PR DESCRIPTION
I also have some changes in the queue based on https://github.com/wildfly-security/wildfly-elytron/pull/632. The change will include a ```maximum-age``` attribute to the ```caching-realm```.