### PR TITLE
[WFLY-7832] Coverity: dereference null value in ClassLoadingAttributeDefinitions (Elytron subsystem)

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/ClassLoadingAttributeDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/ClassLoadingAttributeDefinitions.java
@@ -52,7 +52,7 @@ class ClassLoadingAttributeDefinitions {
 
     static ClassLoader resolveClassLoader(String module) throws ModuleLoadException {
         Module current = Module.getCallerModule();
-        if (module != null) {
+        if (module != null && current != null) {
             ModuleIdentifier mi = ModuleIdentifier.fromString(module);
             current = current.getModule(mi);
         }


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-7832
