### PR TITLE
[WFLY-7945] Elytron mechanism-provider-filtering-sasl-server-factory filters attribute description shows required=true and nillable=false which is not right.

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
@@ -155,7 +155,7 @@ class SaslServerDefinitions {
         .build();
 
     static final ObjectTypeAttributeDefinition MECH_PROVIDER_FILTER = new ObjectTypeAttributeDefinition.Builder(ElytronDescriptionConstants.FILTER, MECHANISM_NAME, PROVIDER_NAME, PROVIDER_VERSION, VERSION_COMPARISON)
-        .setAllowNull(false)
+        .setAllowNull(true)
         .build();
 
     static final ObjectListAttributeDefinition MECH_PROVIDER_FILTERS = new ObjectListAttributeDefinition.Builder(ElytronDescriptionConstants.FILTERS, MECH_PROVIDER_FILTER)


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-7945
