### PR TITLE
[WFLY-7705] LdapRealm referrals tests

### DIFF
--- a/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
+++ b/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
@@ -33,7 +33,8 @@ import java.nio.file.attribute.BasicFileAttributes;
 
 class TestEnvironment extends AdditionalInitialization {
 
-    static final int LDAP_PORT = 11391;
+    static final int LDAPS1_PORT = 11391;
+    static final int LDAPS2_PORT = 11392;
 
     @Override
     protected ControllerInitializer createControllerInitializer() {
@@ -56,15 +57,23 @@ class TestEnvironment extends AdditionalInitialization {
         return initializer;
     }
 
-    public static LdapService startLdapService() {
+    public static void startLdapService() {
         try {
-            return LdapService.builder()
-                    .setWorkingDir(new File("./target/apache-ds/working"))
+            LdapService.builder()
+                    .setWorkingDir(new File("./target/apache-ds/working1"))
                     .createDirectoryService("Test Service")
                     .addPartition("Elytron", "dc=elytron,dc=wildfly,dc=org", 5, "uid")
                     .importLdif(TestEnvironment.class.getResourceAsStream("ldap-schemas.ldif"))
                     .importLdif(TestEnvironment.class.getResourceAsStream("ldap-data.ldif"))
-                    .addTcpServer("Default TCP", "localhost", LDAP_PORT, "localhost.keystore", "Elytron")
+                    .addTcpServer("Default TCP", "localhost", LDAPS1_PORT, "localhost.keystore", "Elytron")
+                    .start();
+            LdapService.builder()
+                    .setWorkingDir(new File("./target/apache-ds/working2"))
+                    .createDirectoryService("Test Service")
+                    .addPartition("Elytron", "dc=elytron,dc=wildfly,dc=org", 5, "uid")
+                    .importLdif(TestEnvironment.class.getResourceAsStream("ldap-schemas.ldif"))
+                    .importLdif(TestEnvironment.class.getResourceAsStream("ldap-referred.ldif"))
+                    .addTcpServer("Default TCP", "localhost", LDAPS2_PORT, "localhost.keystore", "Elytron")
                     .start();
         } catch (Exception e) {
             throw new RuntimeException("Could not start LDAP embedded server.", e);

--- a/src/test/resources/org/wildfly/extension/elytron/ldap-data.ldif
+++ b/src/test/resources/org/wildfly/extension/elytron/ldap-data.ldif
@@ -107,23 +107,7 @@ objectClass: extensibleObject
 objectClass: referral
 objectClass: top
 ou: refUsers
-ref: ldaps://localhost:11391/dc=referredUsers,dc=elytron,dc=wildfly,dc=org
-
-dn: dc=referredUsers,dc=elytron,dc=wildfly,dc=org
-objectclass: top
-objectclass: domain
-dc: referredUsers
-
-dn: uid=refUser,dc=referredUsers,dc=elytron,dc=wildfly,dc=org
-objectClass: top
-objectClass: inetOrgPerson
-objectClass: person
-objectClass: organizationalPerson
-cn: refUserCn
-sn: refUserSn
-uid: refUser
-userPassword:: cGxhaW5QYXNzd29yZA==
-# Password plainPassword
+ref: ldaps://localhost:11392/dc=referredUsers,dc=elytron,dc=wildfly,dc=org
 
 dn: cn=RN1,dc=elytron,dc=wildfly,dc=org
 objectclass: top

--- a/src/test/resources/org/wildfly/extension/elytron/ldap-referred.ldif
+++ b/src/test/resources/org/wildfly/extension/elytron/ldap-referred.ldif
@@ -1,0 +1,40 @@
+version: 1
+
+# === Second LDAP server for referrals testing ===
+
+dn: dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: domain
+dc: elytron
+
+dn: dc=users,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: domain
+dc: users
+
+dn: uid=server,dc=users,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: person
+objectClass: organizationalPerson
+cn: server
+sn: server
+uid: server
+userPassword:: c2VydmVyUGFzc3dvcmQ=
+# Password serverPassword
+
+dn: dc=referredUsers,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: domain
+dc: referredUsers
+
+dn: uid=refUser,dc=referredUsers,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: person
+objectClass: organizationalPerson
+cn: refUserCn
+sn: refUserSn
+uid: refUser
+userPassword:: cGxhaW5QYXNzd29yZA==
+# Password plainPassword


### PR DESCRIPTION
LDAP referrals tests improvement - using two standalone LDAP servers now.

Green tests require https://github.com/wildfly-security/wildfly-elytron/pull/637

https://issues.jboss.org/browse/WFLY-7705