### PR TITLE
[WFLY-8004] Attributes with a default value should be defined with se…

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
@@ -94,7 +94,8 @@ class HttpServerDefinitions {
         .setName(ElytronDescriptionConstants.PATTERN_FILTER)
         .build();
 
-    static final SimpleAttributeDefinition ENABLING = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ENABLING, ModelType.BOOLEAN, false)
+    static final SimpleAttributeDefinition ENABLING = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ENABLING, ModelType.BOOLEAN)
+        .setRequired(false)
         .setAllowExpression(true)
         .setDefaultValue(new ModelNode(true))
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)

--- a/src/main/java/org/wildfly/extension/elytron/IdentityResourceDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/IdentityResourceDefinition.java
@@ -407,7 +407,8 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
     static class PasswordSetHandler implements OperationStepHandler {
 
         static class Bcrypt {
-            static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING, false)
+            static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING)
+                    .setRequired(false)
                     .setDefaultValue(new ModelNode(BCryptPassword.ALGORITHM_BCRYPT))
                     .setValidator(new StringValuesValidator(BCryptPassword.ALGORITHM_BCRYPT))
                     .setAllowExpression(false)
@@ -433,7 +434,8 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
         }
 
         static class Clear {
-            static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING, false)
+            static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING)
+                    .setRequired(false)
                     .setDefaultValue(new ModelNode(ClearPassword.ALGORITHM_CLEAR))
                     .setValidator(new StringValuesValidator(ClearPassword.ALGORITHM_CLEAR))
                     .setAllowExpression(false)
@@ -452,7 +454,8 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
         }
 
         static class SimpleDigest {
-            static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING, false)
+            static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING)
+                    .setRequired(false)
                     .setDefaultValue(new ModelNode(SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_512))
                     .setValidator(new StringValuesValidator(
                             SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_MD2,
@@ -478,7 +481,8 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
         }
 
         static class SaltedSimpleDigest {
-            static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING, false)
+            static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING)
+                    .setRequired(false)
                     .setDefaultValue(new ModelNode(SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512))
                     .setValidator(new StringValuesValidator(
                             SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_MD5,
@@ -510,7 +514,8 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
         }
 
         static class Digest {
-            static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING, false)
+            static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING)
+                    .setRequired(false)
                     .setDefaultValue(new ModelNode(DigestPassword.ALGORITHM_DIGEST_SHA_512))
                     .setValidator(new StringValuesValidator(
                             DigestPassword.ALGORITHM_DIGEST_MD5,

--- a/src/main/java/org/wildfly/extension/elytron/JdbcRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/JdbcRealmDefinition.java
@@ -93,7 +93,8 @@ class JdbcRealmDefinition extends SimpleResourceDefinition {
      */
     static class ClearPasswordObjectDefinition implements PasswordMapperObjectDefinition {
 
-        static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING, false)
+        static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING)
+                .setRequired(false)
                 .setDefaultValue(new ModelNode(ClearPassword.ALGORITHM_CLEAR))
                 .setValidator(new StringValuesValidator(ClearPassword.ALGORITHM_CLEAR))
                 .setAllowExpression(false)
@@ -141,7 +142,8 @@ class JdbcRealmDefinition extends SimpleResourceDefinition {
      */
     static class BcryptPasswordObjectDefinition implements PasswordMapperObjectDefinition {
 
-        static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING, false)
+        static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING)
+                .setRequired(false)
                 .setDefaultValue(new ModelNode(BCryptPassword.ALGORITHM_BCRYPT))
                 .setValidator(new StringValuesValidator(BCryptPassword.ALGORITHM_BCRYPT))
                 .setAllowExpression(false)
@@ -204,7 +206,8 @@ class JdbcRealmDefinition extends SimpleResourceDefinition {
      */
     static class SaltedSimpleDigestObjectDefinition implements PasswordMapperObjectDefinition {
 
-        static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING, false)
+        static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING)
+                .setRequired(false)
                 .setDefaultValue(new ModelNode(SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_MD5))
                 .setValidator(new StringValuesValidator(
                         SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_MD5,
@@ -270,7 +273,8 @@ class JdbcRealmDefinition extends SimpleResourceDefinition {
      */
     static class SimpleDigestMapperObjectDefinition implements PasswordMapperObjectDefinition {
 
-        static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING, false)
+        static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING)
+                .setRequired(false)
                 .setDefaultValue(new ModelNode(SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_MD5))
                 .setValidator(new StringValuesValidator(
                         SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_MD2,
@@ -324,7 +328,8 @@ class JdbcRealmDefinition extends SimpleResourceDefinition {
      */
     static class ScramMapperObjectDefinition implements PasswordMapperObjectDefinition {
 
-        static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING, false)
+        static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING)
+                .setRequired(false)
                 .setDefaultValue(new ModelNode(ScramDigestPassword.ALGORITHM_SCRAM_SHA_256))
                 .setValidator(new StringValuesValidator(
                         ScramDigestPassword.ALGORITHM_SCRAM_SHA_1,

--- a/src/main/java/org/wildfly/extension/elytron/ProviderAttributeDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/ProviderAttributeDefinition.java
@@ -89,6 +89,7 @@ class ProviderAttributeDefinition {
     static final SimpleAttributeDefinition LOAD_SERVICES = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.LOAD_SERVICES, ModelType.BOOLEAN)
         .setAttributeGroup(ElytronDescriptionConstants.CLASS_LOADING)
         .setAllowExpression(true)
+        .setRequired(false)
         .setDefaultValue(new ModelNode(false))
         .build();
 

--- a/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
@@ -145,6 +145,7 @@ class SaslServerDefinitions {
         .build();
 
     static final SimpleAttributeDefinition VERSION_COMPARISON = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.VERSION_COMPARISON, ModelType.STRING, false)
+        .setRequired(false)
         .setAllowExpression(true)
         .setDefaultValue(new ModelNode(ElytronDescriptionConstants.LESS_THAN))
         .setRequires(ElytronDescriptionConstants.PROVIDER_VERSION)


### PR DESCRIPTION
…tRequired(false)

https://issues.jboss.org/browse/WFLY-8004

I did a "git grep setDefaultValue" and used that to drive a search for all such attributes that were configured as required. This is all of them.

The default value removes the requirement for the user to provide a value.

Without this the server will not boot once WFCORE-2249 is fixed.