### PR TITLE
[WFLY-7653] (Reopen) Validate session-timeout and maximum-session-cache-size to be non-negative

### DIFF
--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -3824,14 +3824,14 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="maximum-session-cache-size" type="xs:int" default="0">
+        <xs:attribute name="maximum-session-cache-size" type="xs:nonNegativeInteger" default="0">
             <xs:annotation>
                 <xs:documentation>
                     The maximum number of SSL sessions in the cache. The default value zero means there is no limit.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="session-timeout" type="xs:int" default="0">
+        <xs:attribute name="session-timeout" type="xs:nonNegativeInteger" default="0">
             <xs:annotation>
                 <xs:documentation>
                     The timeout for SSL sessions, in seconds. The default value zero means there is no limit.


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-7653

Corrected the missing check in XSD for clientSSLContextType.
