### PR TITLE
[WFLY-7833] Coverity: dereference null value in PermissionMapperDefinitions (Elytron subsystem)

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
@@ -244,7 +244,7 @@ class PermissionMapperDefinitions {
 
     private static java.security.Permission createPermission(Permission permission) throws StartException {
         Module currentModule = Module.getCallerModule();
-        if (permission.getModule() != null) {
+        if (permission.getModule() != null && currentModule != null) {
             ModuleIdentifier mi = ModuleIdentifier.fromString(permission.getModule());
             try {
                 currentModule = currentModule.getModule(mi);


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-7833

