### PR TITLE
[WFLY-8062] Ensure OperationStepHandler's register and execute RUNTIME stage steps if the operation is being executed on a server, including ADMIN_ONLY, and the host controller.

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/AggregateComponentDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/AggregateComponentDefinition.java
@@ -31,7 +31,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -145,7 +144,7 @@ class AggregateComponentDefinition<T> extends SimpleResourceDefinition {
 
     }
 
-    private static class WriteAttributeHandler<T> extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler<T> extends ElytronRestartParentWriteAttributeHandler {
 
         private final Class<T> serviceType;
         private final RuntimeCapability<?> runtimeCapability;

--- a/src/main/java/org/wildfly/extension/elytron/AggregateRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/AggregateRealmDefinition.java
@@ -29,7 +29,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -131,7 +130,7 @@ class AggregateRealmDefinition extends SimpleResourceDefinition {
 
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler(final String key) {
             super(key, ATTRIBUTES);

--- a/src/main/java/org/wildfly/extension/elytron/AvailableMechanismsRuntimeResource.java
+++ b/src/main/java/org/wildfly/extension/elytron/AvailableMechanismsRuntimeResource.java
@@ -21,7 +21,6 @@ import static org.wildfly.common.Assert.checkNotNullParam;
 
 import java.util.function.Function;
 
-import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.DelegatingResourceDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -59,7 +58,7 @@ class AvailableMechanismsRuntimeResource extends DelegatingResourceDefinition {
         resourceRegistration.registerReadOnlyAttribute(AVAILABLE_MECHANISMS, new AvailableMechanismsHandler());
     }
 
-    private class AvailableMechanismsHandler extends AbstractRuntimeOnlyHandler {
+    private class AvailableMechanismsHandler extends ElytronRuntimeOnlyHandler {
 
         @Override
         protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {

--- a/src/main/java/org/wildfly/extension/elytron/BaseAddHandler.java
+++ b/src/main/java/org/wildfly/extension/elytron/BaseAddHandler.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.capability.RuntimeCapability;
 
 /**
@@ -31,7 +30,7 @@ import org.jboss.as.controller.capability.RuntimeCapability;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-class BaseAddHandler extends AbstractAddStepHandler {
+class BaseAddHandler extends AbstractAddStepHandler implements ElytronOperationStepHandler {
 
     /**
      * Constructor of the add handler that takes an array of {@link AttributeDefinition}.
@@ -72,7 +71,7 @@ class BaseAddHandler extends AbstractAddStepHandler {
      */
     @Override
     protected boolean requiresRuntime(OperationContext context) {
-        return context.isDefaultRequiresRuntime() || context.isNormalServer() && RunningMode.ADMIN_ONLY == context.getRunningMode();
+        return isServerOrHostController(context);
     }
 
 }

--- a/src/main/java/org/wildfly/extension/elytron/CredentialStoreAliasDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/CredentialStoreAliasDefinition.java
@@ -30,8 +30,6 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
-import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -165,7 +163,7 @@ class CredentialStoreAliasDefinition extends SimpleResourceDefinition {
         return  operationAlias.equals(contextAlias);
     }
 
-    private static class AddHandler extends AbstractAddStepHandler {
+    private static class AddHandler extends BaseAddHandler {
 
         AddHandler() {
             super(CONFIG_ATTRIBUTES);
@@ -241,7 +239,7 @@ class CredentialStoreAliasDefinition extends SimpleResourceDefinition {
     }
 
 
-    private static class WriteAttributeHandler extends AbstractWriteAttributeHandler<String> {
+    private static class WriteAttributeHandler extends ElytronWriteAttributeHandler<String> {
 
         WriteAttributeHandler() {
             super(CONFIG_ATTRIBUTES);

--- a/src/main/java/org/wildfly/extension/elytron/CredentialStoreAliasDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/CredentialStoreAliasDefinition.java
@@ -177,7 +177,7 @@ class CredentialStoreAliasDefinition extends SimpleResourceDefinition {
 
             ServiceName credentialStoreServiceName = CREDENTIAL_STORE_UTIL.serviceName(operation);
             @SuppressWarnings("unchecked")
-            ServiceController<CredentialStore> serviceContainer = (ServiceController<CredentialStore>) context.getServiceRegistry(false).getRequiredService(credentialStoreServiceName);
+            ServiceController<CredentialStore> serviceContainer = (ServiceController<CredentialStore>) context.getServiceRegistry(true).getRequiredService(credentialStoreServiceName);
             CredentialStore credentialStore = ((CredentialStoreService) serviceContainer.getService()).getValue();
             try {
                 if (entryType == null || ClearPassword.ALGORITHM_CLEAR.equals(entryType)) {

--- a/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
@@ -30,8 +30,6 @@ import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.RO
 
 import java.security.Provider;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
-import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
@@ -145,7 +143,7 @@ final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
             resourceRegistration.registerReadWriteAttribute(current, null, WRITE);
         }
 
-        resourceRegistration.registerReadOnlyAttribute(STATE, new AbstractRuntimeOnlyHandler() {
+        resourceRegistration.registerReadOnlyAttribute(STATE, new ElytronRuntimeOnlyHandler() {
 
             @Override
             protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
@@ -170,7 +168,7 @@ final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(new CredentialStoreAliasDefinition());
     }
 
-    private static class CredentialStoreAddHandler extends AbstractAddStepHandler {
+    private static class CredentialStoreAddHandler extends BaseAddHandler {
 
         private CredentialStoreAddHandler() {
             super(CREDENTIAL_STORE_RUNTIME_CAPABILITY, CONFIG_ATTRIBUTES);
@@ -240,7 +238,7 @@ final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
      * Runtime Attribute and Operation Handlers
      */
 
-    abstract static class CredentialStoreRuntimeOnlyHandler extends AbstractRuntimeOnlyHandler {
+    abstract static class CredentialStoreRuntimeOnlyHandler extends ElytronRuntimeOnlyHandler {
 
         private final boolean serviceMustBeUp;
         private final boolean writeAccess;

--- a/src/main/java/org/wildfly/extension/elytron/CustomComponentDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/CustomComponentDefinition.java
@@ -40,7 +40,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleMapAttributeDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -179,7 +178,7 @@ class CustomComponentDefinition<T> extends SimpleResourceDefinition {
         }
     }
 
-    private static class WriteAttributeHandler<T> extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler<T> extends ElytronRestartParentWriteAttributeHandler {
 
         private final RuntimeCapability<?> runtimeCapability;
         private final Class<T> serviceType;

--- a/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
@@ -38,7 +38,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleMapAttributeDefinition;
@@ -191,7 +190,7 @@ class DirContextDefinition extends SimpleResourceDefinition {
         };
     }
 
-    private static final AbstractAddStepHandler ADD = new AbstractAddStepHandler(DIR_CONTEXT_RUNTIME_CAPABILITY, ATTRIBUTES) {
+    private static final AbstractAddStepHandler ADD = new BaseAddHandler(DIR_CONTEXT_RUNTIME_CAPABILITY, ATTRIBUTES) {
         protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
 
             RuntimeCapability<Void> runtimeCapability = DIR_CONTEXT_RUNTIME_CAPABILITY.fromBaseCapability(context.getCurrentAddressValue());
@@ -222,7 +221,7 @@ class DirContextDefinition extends SimpleResourceDefinition {
 
     private static final OperationStepHandler REMOVE = new TrivialCapabilityServiceRemoveHandler(ADD, DIR_CONTEXT_RUNTIME_CAPABILITY);
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler() {
             super(ElytronDescriptionConstants.DIR_CONTEXT, ATTRIBUTES);

--- a/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
@@ -48,7 +48,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -378,7 +377,7 @@ class DomainDefinition extends SimpleResourceDefinition {
 
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler(String parentKeyName) {
             super(parentKeyName, ATTRIBUTES);

--- a/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -36,8 +36,6 @@ import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.RO
 import java.security.Provider;
 
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
-import org.jboss.as.controller.AbstractRemoveStepHandler;
-import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationContext.AttachmentKey;
 import org.jboss.as.controller.OperationContext.Stage;
@@ -218,7 +216,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
         OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(INITIAL_PROVIDERS, FINAL_PROVIDERS);
         resourceRegistration.registerReadWriteAttribute(INITIAL_PROVIDERS, null, writeHandler);
         resourceRegistration.registerReadWriteAttribute(FINAL_PROVIDERS, null, writeHandler);
-        resourceRegistration.registerReadWriteAttribute(DEFAULT_AUTHENTICATION_CONTEXT, null, new AbstractWriteAttributeHandler<Void>(DEFAULT_AUTHENTICATION_CONTEXT) {
+        resourceRegistration.registerReadWriteAttribute(DEFAULT_AUTHENTICATION_CONTEXT, null, new ElytronWriteAttributeHandler<Void>(DEFAULT_AUTHENTICATION_CONTEXT) {
 
             @Override
             protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName,
@@ -271,7 +269,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
         return null;
     }
 
-    private static class ElytronAdd extends AbstractBoottimeAddStepHandler {
+    private static class ElytronAdd extends AbstractBoottimeAddStepHandler implements ElytronOperationStepHandler {
 
         private ElytronAdd() {
             super(ELYTRON_RUNTIME_CAPABILITY, DEFAULT_AUTHENTICATION_CONTEXT, INITIAL_PROVIDERS, FINAL_PROVIDERS);
@@ -332,9 +330,13 @@ class ElytronDefinition extends SimpleResourceDefinition {
             AUTHENITCATION_CONTEXT_PROCESSOR.setDefaultAuthenticationContext(null);
         }
 
+        @Override
+        protected boolean requiresRuntime(final OperationContext context) {
+            return isServerOrHostController(context);
+        }
     }
 
-    private static class ElytronRemove extends AbstractRemoveStepHandler {
+    private static class ElytronRemove extends ElytronRemoveStepHandler {
 
         private ElytronRemove() {
             super(ELYTRON_RUNTIME_CAPABILITY);

--- a/src/main/java/org/wildfly/extension/elytron/ElytronOperationStepHandler.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronOperationStepHandler.java
@@ -1,0 +1,27 @@
+package org.wildfly.extension.elytron;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+
+/**
+ * An {@link OperationStepHandler} which adds the ability to check whether or not the operation is running on a server
+ * or host controller.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+interface ElytronOperationStepHandler extends OperationStepHandler {
+
+    /**
+     * Checks if the context is running on a {@linkplain ProcessType#isServer() server} or on a host controller. This
+     * will return {@code true} even if the server is running in {@link org.jboss.as.controller.RunningMode#ADMIN_ONLY}.
+     *
+     * @param context the current operation context
+     *
+     * @return {@code true} if the current context is a server or a host controller
+     */
+    default boolean isServerOrHostController(final OperationContext context) {
+        return context.getProcessType().isServer() || !ModelDescriptionConstants.PROFILE.equals(context.getCurrentAddress().getElement(0).getKey());
+    }
+}

--- a/src/main/java/org/wildfly/extension/elytron/ElytronRemoveStepHandler.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronRemoveStepHandler.java
@@ -1,0 +1,31 @@
+package org.wildfly.extension.elytron;
+
+import java.util.Set;
+
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.capability.RuntimeCapability;
+
+/**
+ * Extends the {@link AbstractRemoveStepHandler} overriding the {@link #requiresRuntime(OperationContext)}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class ElytronRemoveStepHandler extends AbstractRemoveStepHandler implements ElytronOperationStepHandler {
+    protected ElytronRemoveStepHandler() {
+        super();
+    }
+
+    protected ElytronRemoveStepHandler(final RuntimeCapability... capabilities) {
+        super(capabilities);
+    }
+
+    protected ElytronRemoveStepHandler(final Set<RuntimeCapability> capabilities) {
+        super(capabilities);
+    }
+
+    @Override
+    protected boolean requiresRuntime(final OperationContext context) {
+        return isServerOrHostController(context);
+    }
+}

--- a/src/main/java/org/wildfly/extension/elytron/ElytronRestartParentWriteAttributeHandler.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronRestartParentWriteAttributeHandler.java
@@ -1,0 +1,27 @@
+package org.wildfly.extension.elytron;
+
+import java.util.Collection;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.RestartParentWriteAttributeHandler;
+
+/**
+ * Extends the {@link RestartParentWriteAttributeHandler} overriding the {@link #requiresRuntime(OperationContext)}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class ElytronRestartParentWriteAttributeHandler extends RestartParentWriteAttributeHandler implements ElytronOperationStepHandler {
+    ElytronRestartParentWriteAttributeHandler(final String parentKeyName, final AttributeDefinition... definitions) {
+        super(parentKeyName, definitions);
+    }
+
+    ElytronRestartParentWriteAttributeHandler(final String parentKeyName, final Collection<AttributeDefinition> definitions) {
+        super(parentKeyName, definitions);
+    }
+
+    @Override
+    protected boolean requiresRuntime(final OperationContext context) {
+        return isServerOrHostController(context);
+    }
+}

--- a/src/main/java/org/wildfly/extension/elytron/ElytronRuntimeOnlyHandler.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronRuntimeOnlyHandler.java
@@ -1,0 +1,21 @@
+package org.wildfly.extension.elytron;
+
+import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Extends the {@link AbstractRuntimeOnlyHandler} only {@linkplain #execute(OperationContext, ModelNode) executing} the
+ * if the {@link #isServerOrHostController(OperationContext)} returns {@code true}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class ElytronRuntimeOnlyHandler extends AbstractRuntimeOnlyHandler implements ElytronOperationStepHandler {
+    @Override
+    public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+        if (isServerOrHostController(context)) {
+            super.execute(context, operation);
+        }
+    }
+}

--- a/src/main/java/org/wildfly/extension/elytron/ElytronWriteAttributeHandler.java
+++ b/src/main/java/org/wildfly/extension/elytron/ElytronWriteAttributeHandler.java
@@ -1,0 +1,27 @@
+package org.wildfly.extension.elytron;
+
+import java.util.Collection;
+
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+
+/**
+ * Extends the {@link AbstractWriteAttributeHandler} overriding the {@link #requiresRuntime(OperationContext)}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class ElytronWriteAttributeHandler<V> extends AbstractWriteAttributeHandler<V> implements ElytronOperationStepHandler {
+    protected ElytronWriteAttributeHandler(final AttributeDefinition... definitions) {
+        super(definitions);
+    }
+
+    protected ElytronWriteAttributeHandler(final Collection<AttributeDefinition> definitions) {
+        super(definitions);
+    }
+
+    @Override
+    protected boolean requiresRuntime(final OperationContext context) {
+        return isServerOrHostController(context);
+    }
+}

--- a/src/main/java/org/wildfly/extension/elytron/FileSystemRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/FileSystemRealmDefinition.java
@@ -35,7 +35,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -165,7 +164,7 @@ class FileSystemRealmDefinition extends SimpleResourceDefinition {
 
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler() {
             super(ElytronDescriptionConstants.FILESYSTEM_REALM, ATTRIBUTES);

--- a/src/main/java/org/wildfly/extension/elytron/FilteringKeyStoreDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/FilteringKeyStoreDefinition.java
@@ -27,7 +27,6 @@ import static org.wildfly.extension.elytron.ServiceStateDefinition.populateRespo
 
 import java.security.KeyStore;
 
-import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -35,7 +34,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -99,7 +97,7 @@ class FilteringKeyStoreDefinition extends SimpleResourceDefinition {
             resourceRegistration.registerReadWriteAttribute(current, null, WRITE);
         }
 
-        resourceRegistration.registerReadOnlyAttribute(STATE, new AbstractRuntimeOnlyHandler() {
+        resourceRegistration.registerReadOnlyAttribute(STATE, new ElytronRuntimeOnlyHandler() {
 
             @Override
             protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
@@ -162,7 +160,7 @@ class FilteringKeyStoreDefinition extends SimpleResourceDefinition {
         }
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler() {
             super(ElytronDescriptionConstants.FILTERING_KEY_STORE, CONFIG_ATTRIBUTES);

--- a/src/main/java/org/wildfly/extension/elytron/FilteringKeyStoreDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/FilteringKeyStoreDefinition.java
@@ -141,7 +141,8 @@ class FilteringKeyStoreDefinition extends SimpleResourceDefinition {
             ServiceBuilder<KeyStore> serviceBuilder = serviceTarget.addService(serviceName, filteringKeyStoreService).setInitialMode(ServiceController.Mode.ACTIVE);
 
             serviceBuilder.addDependency(sourceKeyStoreServiceName);
-            ServiceRegistry serviceRegistry = context.getServiceRegistry(false);
+            // Retrieving the modifiable registry here as the ModifiedKeyStoreService may be modified
+            ServiceRegistry serviceRegistry = context.getServiceRegistry(true);
             ServiceController<?> controller = serviceRegistry.getRequiredService(sourceKeyStoreServiceName);
             serviceInjector.setValue(() -> (ModifiableKeyStoreService) controller.getService());
 

--- a/src/main/java/org/wildfly/extension/elytron/IdentityResourceDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/IdentityResourceDefinition.java
@@ -193,7 +193,9 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
 
         @Override
         protected void executeRuntimeStep(final OperationContext context, final ModelNode operation) throws OperationFailedException {
-            ServiceRegistry serviceRegistry = context.getServiceRegistry(false);
+            // Retrieving the modifiable registry here as the SecurityDomain is used to create a new authentication
+            // context.
+            ServiceRegistry serviceRegistry = context.getServiceRegistry(true);
             RuntimeCapability<Void> runtimeCapability = SECURITY_DOMAIN_RUNTIME_CAPABILITY.fromBaseCapability(context.getCurrentAddressValue());
             ServiceName domainServiceName = runtimeCapability.getCapabilityServiceName(SecurityDomain.class);
             ServiceController<SecurityDomain> serviceController = getRequiredService(serviceRegistry, domainServiceName, SecurityDomain.class);
@@ -761,7 +763,9 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
         }
 
         private SecurityDomain getSecurityDomain(OperationContext context, ModelNode operation) {
-            ServiceRegistry serviceRegistry = context.getServiceRegistry(false);
+            // Retrieving the modifiable registry here as the SecurityDomain is used to create a new authentication
+            // context.
+            ServiceRegistry serviceRegistry = context.getServiceRegistry(true);
             ServiceController<SecurityDomain> serviceController = getRequiredService(serviceRegistry, DOMAIN_SERVICE_UTIL.serviceName(operation), SecurityDomain.class);
             Service<SecurityDomain> service = serviceController.getService();
 

--- a/src/main/java/org/wildfly/extension/elytron/IdentityResourceDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/IdentityResourceDefinition.java
@@ -18,7 +18,6 @@
 
 package org.wildfly.extension.elytron;
 
-import static org.jboss.as.controller.OperationContext.ResultHandler.NOOP_RESULT_HANDLER;
 import static org.wildfly.extension.elytron.Capabilities.MODIFIABLE_SECURITY_REALM_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.ElytronExtension.getRequiredService;
@@ -120,70 +119,66 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
         AttributeRemoveHandler.register(resourceRegistration, getResourceDescriptionResolver());
     }
 
-    private static class IdentityAddHandler implements OperationStepHandler {
+    private static class IdentityAddHandler extends BaseAddHandler {
 
         private IdentityAddHandler() {
         }
 
         @Override
-        public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
-            context.addStep(operation, (context1, operation1) -> {
-                ModifiableSecurityRealm modifiableRealm = getModifiableSecurityRealm(context);
-                String principalName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
+        protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+            ModifiableSecurityRealm modifiableRealm = getModifiableSecurityRealm(context);
+            String principalName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
 
-                ModifiableRealmIdentity identity = null;
-                try {
-                    identity = modifiableRealm.getRealmIdentityForUpdate(new NamePrincipal(principalName));
+            ModifiableRealmIdentity identity = null;
+            try {
+                identity = modifiableRealm.getRealmIdentityForUpdate(new NamePrincipal(principalName));
 
-                    if (identity.exists()) {
-                        throw ROOT_LOGGER.identityAlreadyExists(principalName);
-                    }
-
-                    identity.create();
-                } catch (RealmUnavailableException e) {
-                    throw ROOT_LOGGER.couldNotCreateIdentity(principalName, e);
-                } finally {
-                    if (identity != null) {
-                        identity.dispose();
-                    }
+                if (identity.exists()) {
+                    throw ROOT_LOGGER.identityAlreadyExists(principalName);
                 }
-            }, OperationContext.Stage.RUNTIME);
+
+                identity.create();
+            } catch (RealmUnavailableException e) {
+                throw ROOT_LOGGER.couldNotCreateIdentity(principalName, e);
+            } finally {
+                if (identity != null) {
+                    identity.dispose();
+                }
+            }
         }
     }
 
-    private static class IdentityRemoveHandler implements OperationStepHandler {
+    private static class IdentityRemoveHandler extends ElytronRuntimeOnlyHandler {
 
         private IdentityRemoveHandler() {
         }
 
         @Override
-        public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
-            context.addStep(operation, (context1, operation1) -> {
-                ModifiableSecurityRealm modifiableRealm = getModifiableSecurityRealm(context1);
-                String principalName = PathAddress.pathAddress(operation1.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
+        protected void executeRuntimeStep(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            ModifiableSecurityRealm modifiableRealm = getModifiableSecurityRealm(context);
+            String principalName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
 
-                ModifiableRealmIdentity realmIdentity = null;
-                try {
-                    realmIdentity = modifiableRealm.getRealmIdentityForUpdate(new NamePrincipal(principalName));
+            ModifiableRealmIdentity realmIdentity = null;
+            try {
+                realmIdentity = modifiableRealm.getRealmIdentityForUpdate(new NamePrincipal(principalName));
 
-                    if (!realmIdentity.exists()) {
-                        throw new OperationFailedException(ROOT_LOGGER.identityNotFound(principalName));
-                    }
-
-                    realmIdentity.delete();
-                    realmIdentity.dispose();
-                } catch (RealmUnavailableException e) {
-                    throw ROOT_LOGGER.couldNotCreateIdentity(principalName, e);
-                } finally {
-                    if (realmIdentity != null) {
-                        realmIdentity.dispose();
-                    }
+                if (!realmIdentity.exists()) {
+                    throw new OperationFailedException(ROOT_LOGGER.identityNotFound(principalName));
                 }
-            }, OperationContext.Stage.RUNTIME);
+
+                realmIdentity.delete();
+                realmIdentity.dispose();
+            } catch (RealmUnavailableException e) {
+                throw ROOT_LOGGER.couldNotCreateIdentity(principalName, e);
+            } finally {
+                if (realmIdentity != null) {
+                    realmIdentity.dispose();
+                }
+            }
         }
     }
 
-    static class ReadSecurityDomainIdentityHandler implements OperationStepHandler {
+    static class ReadSecurityDomainIdentityHandler extends ElytronRuntimeOnlyHandler {
 
         public static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.NAME, ModelType.STRING, false)
                 .setAllowExpression(false)
@@ -197,53 +192,49 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
         }
 
         @Override
-        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            context.addStep(operation, (parentContext, parentOperation) -> {
-                ServiceRegistry serviceRegistry = parentContext.getServiceRegistry(false);
-                RuntimeCapability<Void> runtimeCapability = SECURITY_DOMAIN_RUNTIME_CAPABILITY.fromBaseCapability(parentContext.getCurrentAddressValue());
-                ServiceName domainServiceName = runtimeCapability.getCapabilityServiceName(SecurityDomain.class);
-                ServiceController<SecurityDomain> serviceController = getRequiredService(serviceRegistry, domainServiceName, SecurityDomain.class);
-                SecurityDomain domain = serviceController.getValue();
-                ServerAuthenticationContext authenticationContext = domain.createNewAuthenticationContext();
-                String principalName = NAME.resolveModelAttribute(parentContext, parentOperation).asString();
+        protected void executeRuntimeStep(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            ServiceRegistry serviceRegistry = context.getServiceRegistry(false);
+            RuntimeCapability<Void> runtimeCapability = SECURITY_DOMAIN_RUNTIME_CAPABILITY.fromBaseCapability(context.getCurrentAddressValue());
+            ServiceName domainServiceName = runtimeCapability.getCapabilityServiceName(SecurityDomain.class);
+            ServiceController<SecurityDomain> serviceController = getRequiredService(serviceRegistry, domainServiceName, SecurityDomain.class);
+            SecurityDomain domain = serviceController.getValue();
+            ServerAuthenticationContext authenticationContext = domain.createNewAuthenticationContext();
+            String principalName = NAME.resolveModelAttribute(context, operation).asString();
 
-                try {
-                    authenticationContext.setAuthenticationName(principalName);
+            try {
+                authenticationContext.setAuthenticationName(principalName);
 
-                    if (!authenticationContext.exists()) {
-                        parentContext.getFailureDescription().add(ROOT_LOGGER.identityNotFound(principalName));
-                        return;
-                    }
-
-                    if (!authenticationContext.authorize(principalName)) {
-                        parentContext.getFailureDescription().add(ROOT_LOGGER.identityNotAuthorized(principalName));
-                        return;
-                    }
-
-                    SecurityIdentity identity = authenticationContext.getAuthorizedIdentity();
-                    ModelNode result = parentContext.getResult();
-
-                    result.get(ElytronDescriptionConstants.NAME).set(principalName);
-
-                    ModelNode attributesNode = result.get(ElytronDescriptionConstants.ATTRIBUTES);
-
-                    identity.getAttributes().entries().forEach(entry -> {
-                        ModelNode entryNode = attributesNode.get(entry.getKey()).setEmptyList();
-                        entry.forEach(value -> entryNode.add(value));
-                    });
-
-                    ModelNode rolesNode = result.get(ElytronDescriptionConstants.ROLES);
-                    identity.getRoles().forEach(roleName -> rolesNode.add(roleName));
-
-                    parentContext.completeStep(NOOP_RESULT_HANDLER);
-                } catch (RealmUnavailableException e) {
-                    throw ROOT_LOGGER.couldNotReadIdentity(principalName, domainServiceName, e);
+                if (!authenticationContext.exists()) {
+                    context.getFailureDescription().add(ROOT_LOGGER.identityNotFound(principalName));
+                    return;
                 }
-            }, OperationContext.Stage.RUNTIME);
+
+                if (!authenticationContext.authorize(principalName)) {
+                    context.getFailureDescription().add(ROOT_LOGGER.identityNotAuthorized(principalName));
+                    return;
+                }
+
+                SecurityIdentity identity = authenticationContext.getAuthorizedIdentity();
+                ModelNode result = context.getResult();
+
+                result.get(ElytronDescriptionConstants.NAME).set(principalName);
+
+                ModelNode attributesNode = result.get(ElytronDescriptionConstants.ATTRIBUTES);
+
+                identity.getAttributes().entries().forEach(entry -> {
+                    ModelNode entryNode = attributesNode.get(entry.getKey()).setEmptyList();
+                    entry.forEach(value -> entryNode.add(value));
+                });
+
+                ModelNode rolesNode = result.get(ElytronDescriptionConstants.ROLES);
+                identity.getRoles().forEach(roleName -> rolesNode.add(roleName));
+            } catch (RealmUnavailableException e) {
+                throw ROOT_LOGGER.couldNotReadIdentity(principalName, domainServiceName, e);
+            }
         }
     }
 
-    static class ReadIdentityHandler implements OperationStepHandler {
+    static class ReadIdentityHandler extends ElytronRuntimeOnlyHandler {
 
         static void register(ManagementResourceRegistration resourceRegistration, ResourceDescriptionResolver descriptionResolver) {
             resourceRegistration.registerOperationHandler(new SimpleOperationDefinition(ElytronDescriptionConstants.READ_IDENTITY, descriptionResolver), new ReadIdentityHandler());
@@ -253,56 +244,52 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
         }
 
         @Override
-        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            context.addStep(operation, (parentContext, parentOperation) -> {
-                String principalName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
-                ModifiableRealmIdentity realmIdentity = getRealmIdentity(context);
+        protected void executeRuntimeStep(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            String principalName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
+            ModifiableRealmIdentity realmIdentity = getRealmIdentity(context);
 
-                try {
-                    if (!realmIdentity.exists()) {
-                        parentContext.getFailureDescription().add(ROOT_LOGGER.identityNotFound(principalName));
-                        return;
-                    }
-                    AuthorizationIdentity identity = realmIdentity.getAuthorizationIdentity();
-                    ModelNode result = parentContext.getResult();
-
-                    result.get(ElytronDescriptionConstants.NAME).set(principalName);
-
-                    ModelNode attributesNode = result.get(ElytronDescriptionConstants.ATTRIBUTES);
-
-                    identity.getAttributes().entries().forEach(entry -> {
-                        ModelNode entryNode = attributesNode.get(entry.getKey()).setEmptyList();
-                        entry.forEach(value -> entryNode.add(value));
-                    });
-
-                    ModelNode credentialsNode = result.get(ElytronDescriptionConstants.CREDENTIALS).setEmptyList();
-                    getCredentials(realmIdentity).forEach(password -> {
-                        String passwordType;
-                        if (password instanceof BCryptPassword) {
-                            passwordType = ElytronDescriptionConstants.BCRYPT;
-                        } else if (password instanceof ClearPassword) {
-                            passwordType = ElytronDescriptionConstants.CLEAR;
-                        } else if (password instanceof SimpleDigestPassword) {
-                            passwordType = ElytronDescriptionConstants.SIMPLE_DIGEST;
-                        } else if (password instanceof SaltedSimpleDigestPassword) {
-                            passwordType = ElytronDescriptionConstants.SALTED_SIMPLE_DIGEST;
-                        } else if (password instanceof DigestPassword) {
-                            passwordType = ElytronDescriptionConstants.DIGEST;
-                        } else {
-                            throw ROOT_LOGGER.unsupportedPasswordType(password.getClass());
-                        }
-                        credentialsNode.add(passwordType);
-                    });
-
-                    parentContext.completeStep(NOOP_RESULT_HANDLER);
-                } catch (RealmUnavailableException e) {
-                    throw ROOT_LOGGER.couldNotReadIdentity(principalName, e);
+            try {
+                if (!realmIdentity.exists()) {
+                    context.getFailureDescription().add(ROOT_LOGGER.identityNotFound(principalName));
+                    return;
                 }
-            }, OperationContext.Stage.RUNTIME);
+                AuthorizationIdentity identity = realmIdentity.getAuthorizationIdentity();
+                ModelNode result = context.getResult();
+
+                result.get(ElytronDescriptionConstants.NAME).set(principalName);
+
+                ModelNode attributesNode = result.get(ElytronDescriptionConstants.ATTRIBUTES);
+
+                identity.getAttributes().entries().forEach(entry -> {
+                    ModelNode entryNode = attributesNode.get(entry.getKey()).setEmptyList();
+                    entry.forEach(value -> entryNode.add(value));
+                });
+
+                ModelNode credentialsNode = result.get(ElytronDescriptionConstants.CREDENTIALS).setEmptyList();
+                getCredentials(realmIdentity).forEach(password -> {
+                    String passwordType;
+                    if (password instanceof BCryptPassword) {
+                        passwordType = ElytronDescriptionConstants.BCRYPT;
+                    } else if (password instanceof ClearPassword) {
+                        passwordType = ElytronDescriptionConstants.CLEAR;
+                    } else if (password instanceof SimpleDigestPassword) {
+                        passwordType = ElytronDescriptionConstants.SIMPLE_DIGEST;
+                    } else if (password instanceof SaltedSimpleDigestPassword) {
+                        passwordType = ElytronDescriptionConstants.SALTED_SIMPLE_DIGEST;
+                    } else if (password instanceof DigestPassword) {
+                        passwordType = ElytronDescriptionConstants.DIGEST;
+                    } else {
+                        throw ROOT_LOGGER.unsupportedPasswordType(password.getClass());
+                    }
+                    credentialsNode.add(passwordType);
+                });
+            } catch (RealmUnavailableException e) {
+                throw ROOT_LOGGER.couldNotReadIdentity(principalName, e);
+            }
         }
     }
 
-    static class AttributeAddHandler implements OperationStepHandler {
+    static class AttributeAddHandler extends ElytronRuntimeOnlyHandler {
 
         public static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.NAME, ModelType.STRING, false)
                 .setAllowExpression(false)
@@ -322,33 +309,29 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
         }
 
         @Override
-        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            context.addStep(operation, (parentContext, parentOperation) -> {
-                ModifiableRealmIdentity realmIdentity = getRealmIdentity(context);
-                AuthorizationIdentity authorizationIdentity;
+        protected void executeRuntimeStep(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            ModifiableRealmIdentity realmIdentity = getRealmIdentity(context);
+            AuthorizationIdentity authorizationIdentity;
 
-                try {
-                    authorizationIdentity = realmIdentity.getAuthorizationIdentity();
-                } catch (RealmUnavailableException e) {
-                    throw ROOT_LOGGER.couldNotObtainAuthorizationIdentity(e);
-                }
+            try {
+                authorizationIdentity = realmIdentity.getAuthorizationIdentity();
+            } catch (RealmUnavailableException e) {
+                throw ROOT_LOGGER.couldNotObtainAuthorizationIdentity(e);
+            }
 
-                try {
-                    Attributes attributes = new MapAttributes(authorizationIdentity.getAttributes());
-                    String name = NAME.resolveModelAttribute(context, operation).asString();
-                    VALUES.resolveModelAttribute(parentContext, parentOperation).asList().forEach(modelNode -> attributes.addLast(name, modelNode.asString()));
+            try {
+                Attributes attributes = new MapAttributes(authorizationIdentity.getAttributes());
+                String name = NAME.resolveModelAttribute(context, operation).asString();
+                VALUES.resolveModelAttribute(context, operation).asList().forEach(modelNode -> attributes.addLast(name, modelNode.asString()));
 
-                    realmIdentity.setAttributes(attributes);
-                } catch (RealmUnavailableException e) {
-                    throw ROOT_LOGGER.couldNotAddAttribute(e);
-                }
-
-                parentContext.completeStep(NOOP_RESULT_HANDLER);
-            }, OperationContext.Stage.RUNTIME);
+                realmIdentity.setAttributes(attributes);
+            } catch (RealmUnavailableException e) {
+                throw ROOT_LOGGER.couldNotAddAttribute(e);
+            }
         }
     }
 
-    static class AttributeRemoveHandler implements OperationStepHandler {
+    static class AttributeRemoveHandler extends ElytronRuntimeOnlyHandler {
 
         public static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.NAME, ModelType.STRING, false)
                 .setAllowExpression(false)
@@ -369,42 +352,38 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
         }
 
         @Override
-        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            context.addStep(operation, (parentContext, parentOperation) -> {
-                ModifiableRealmIdentity realmIdentity = getRealmIdentity(context);
-                AuthorizationIdentity authorizationIdentity;
+        protected void executeRuntimeStep(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            ModifiableRealmIdentity realmIdentity = getRealmIdentity(context);
+            AuthorizationIdentity authorizationIdentity;
 
-                try {
-                    authorizationIdentity = realmIdentity.getAuthorizationIdentity();
-                } catch (RealmUnavailableException e) {
-                    throw ROOT_LOGGER.couldNotObtainAuthorizationIdentity(e);
-                }
+            try {
+                authorizationIdentity = realmIdentity.getAuthorizationIdentity();
+            } catch (RealmUnavailableException e) {
+                throw ROOT_LOGGER.couldNotObtainAuthorizationIdentity(e);
+            }
 
-                try {
-                    Attributes attributes = new MapAttributes(authorizationIdentity.getAttributes());
+            try {
+                Attributes attributes = new MapAttributes(authorizationIdentity.getAttributes());
 
-                    String name = NAME.resolveModelAttribute(context, operation).asString();
-                    ModelNode valuesNode = VALUES.resolveModelAttribute(parentContext, parentOperation);
+                String name = NAME.resolveModelAttribute(context, operation).asString();
+                ModelNode valuesNode = VALUES.resolveModelAttribute(context, operation);
 
-                    if (valuesNode.isDefined()) {
-                        for (ModelNode valueNode : valuesNode.asList()) {
-                            attributes.removeAll(name, valueNode.asString());
-                        }
-                    } else {
-                        attributes.remove(name);
+                if (valuesNode.isDefined()) {
+                    for (ModelNode valueNode : valuesNode.asList()) {
+                        attributes.removeAll(name, valueNode.asString());
                     }
-
-                    realmIdentity.setAttributes(attributes);
-                } catch (RealmUnavailableException e) {
-                    throw ROOT_LOGGER.couldNotRemoveAttribute(e);
+                } else {
+                    attributes.remove(name);
                 }
 
-                parentContext.completeStep(NOOP_RESULT_HANDLER);
-            }, OperationContext.Stage.RUNTIME);
+                realmIdentity.setAttributes(attributes);
+            } catch (RealmUnavailableException e) {
+                throw ROOT_LOGGER.couldNotRemoveAttribute(e);
+            }
         }
     }
 
-    static class PasswordSetHandler implements OperationStepHandler {
+    static class PasswordSetHandler extends ElytronRuntimeOnlyHandler {
 
         static class Bcrypt {
             static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING)
@@ -550,21 +529,18 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
         }
 
         @Override
-        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            context.addStep(operation, (parentContext, parentOperation) -> {
-                ModifiableRealmIdentity realmIdentity = getRealmIdentity(context);
-                List<ModelNode> modelNodes = parentOperation.asList();
-                Property passwordProperty = modelNodes.get(2).asProperty();
-                PathAddress currentAddress = parentContext.getCurrentAddress();
-                String principalName = currentAddress.getLastElement().getValue();
+        protected void executeRuntimeStep(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            ModifiableRealmIdentity realmIdentity = getRealmIdentity(context);
+            List<ModelNode> modelNodes = operation.asList();
+            Property passwordProperty = modelNodes.get(2).asProperty();
+            PathAddress currentAddress = context.getCurrentAddress();
+            String principalName = currentAddress.getLastElement().getValue();
 
-                try {
-                    realmIdentity.setCredentials(Collections.singleton( new PasswordCredential(createPassword(parentContext, principalName, passwordProperty))));
-                } catch (NoSuchAlgorithmException | InvalidKeySpecException | RealmUnavailableException e) {
-                    throw ROOT_LOGGER.couldNotCreatePassword(e);
-                }
-                parentContext.completeStep(NOOP_RESULT_HANDLER);
-            }, OperationContext.Stage.RUNTIME);
+            try {
+                realmIdentity.setCredentials(Collections.singleton(new PasswordCredential(createPassword(context, principalName, passwordProperty))));
+            } catch (NoSuchAlgorithmException | InvalidKeySpecException | RealmUnavailableException e) {
+                throw ROOT_LOGGER.couldNotCreatePassword(e);
+            }
         }
 
         private Password createPassword(final OperationContext parentContext, final String principalName, Property passwordProperty) throws OperationFailedException, NoSuchAlgorithmException, InvalidKeySpecException {
@@ -611,7 +587,7 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
      * @throws OperationFailedException if any error occurs obtaining the reference to the security realm.
      */
     private static ModifiableSecurityRealm getModifiableSecurityRealm(OperationContext context) throws OperationFailedException {
-        ServiceRegistry serviceRegistry = context.getServiceRegistry(false);
+        ServiceRegistry serviceRegistry = context.getServiceRegistry(true);
         PathAddress currentAddress = context.getCurrentAddress();
         RuntimeCapability<Void> runtimeCapability = MODIFIABLE_SECURITY_REALM_RUNTIME_CAPABILITY.fromBaseCapability(currentAddress.subAddress(0, currentAddress.size() - 1).getLastElement().getValue());
         ServiceName realmName = runtimeCapability.getCapabilityServiceName();
@@ -707,7 +683,7 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
      *
      * <p>This operation is very verbose in order to push messages back to CLI during tests.
      */
-    static class AuthenticatorOperationHandler implements OperationStepHandler {
+    static class AuthenticatorOperationHandler extends ElytronRuntimeOnlyHandler {
 
         private static final ServiceUtil<SecurityDomain> DOMAIN_SERVICE_UTIL = ServiceUtil.newInstance(SECURITY_DOMAIN_RUNTIME_CAPABILITY, ElytronDescriptionConstants.SECURITY_DOMAIN, SecurityDomain.class);
 
@@ -740,49 +716,43 @@ class IdentityResourceDefinition extends SimpleResourceDefinition {
         }
 
         @Override
-        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            context.addStep((contextStep, operationStep) -> {
-                String principalName = USER_NAME.resolveModelAttribute(context, operation).asString();
-                String password = PASSWORD.resolveModelAttribute(context, operation).asString();
-                SecurityDomain securityDomain = getSecurityDomain(context, operation);
+        protected void executeRuntimeStep(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            String principalName = USER_NAME.resolveModelAttribute(context, operation).asString();
+            String password = PASSWORD.resolveModelAttribute(context, operation).asString();
+            SecurityDomain securityDomain = getSecurityDomain(context, operation);
 
-                try {
-                    ServerAuthenticationContext authenticationContext = securityDomain.createNewAuthenticationContext();
+            try {
+                ServerAuthenticationContext authenticationContext = securityDomain.createNewAuthenticationContext();
 
-                    authenticationContext.setAuthenticationName(principalName);
+                authenticationContext.setAuthenticationName(principalName);
 
-                    if (!authenticationContext.exists()) {
-                        addFailureDescription("Principal [" + principalName + "] does not exist.", context);
+                if (!authenticationContext.exists()) {
+                    addFailureDescription("Principal [" + principalName + "] does not exist.", context);
+                    return;
+                }
+
+                // for now, only clear passwords. we can provide an enum with different types later. if necessary.
+                if (authenticationContext.verifyEvidence(new PasswordGuessEvidence(password.toCharArray()))) {
+                    authenticationContext.authorize();
+                    authenticationContext.succeed();
+
+                    SecurityIdentity authorizedIdentity = authenticationContext.getAuthorizedIdentity();
+
+                    if (authorizedIdentity == null) {
+                        addFailureDescription("Principal [" + principalName + "] authenticated but no identity could be obtained.", context);
                         return;
                     }
 
-                    // for now, only clear passwords. we can provide an enum with different types later. if necessary.
-                    if (authenticationContext.verifyEvidence(new PasswordGuessEvidence(password.toCharArray()))) {
-                        authenticationContext.authorize();
-                        authenticationContext.succeed();
-
-                        SecurityIdentity authorizedIdentity = authenticationContext.getAuthorizedIdentity();
-
-                        if (authorizedIdentity == null) {
-                            addFailureDescription("Principal [" + principalName + "] authenticated but no identity could be obtained.", context);
-                            return;
-                        }
-
-                        context.getResult().add("Principal [" + principalName + "] successfully authenticated.");
-                        context.getResult().add("Roles are " + authorizedIdentity.getRoles() + ".");
-                    } else {
-                        authenticationContext.fail();
-                        addFailureDescription("Invalid credentials for Principal [" + principalName + "].", context);
-                    }
-                } catch (Exception cause) {
-                    addFailureDescription(cause.getMessage(), context);
-                    ElytronSubsystemMessages.ROOT_LOGGER.error(cause);
-                } finally {
-                    context.completeStep(OperationContext.ResultHandler.NOOP_RESULT_HANDLER);
+                    context.getResult().add("Principal [" + principalName + "] successfully authenticated.");
+                    context.getResult().add("Roles are " + authorizedIdentity.getRoles() + ".");
+                } else {
+                    authenticationContext.fail();
+                    addFailureDescription("Invalid credentials for Principal [" + principalName + "].", context);
                 }
-
-
-            }, OperationContext.Stage.RUNTIME);
+            } catch (Exception cause) {
+                addFailureDescription(cause.getMessage(), context);
+                ElytronSubsystemMessages.ROOT_LOGGER.error(cause);
+            }
         }
 
         private void addFailureDescription(String message, OperationContext context) {

--- a/src/main/java/org/wildfly/extension/elytron/JdbcRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/JdbcRealmDefinition.java
@@ -46,7 +46,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -609,7 +608,7 @@ class JdbcRealmDefinition extends SimpleResourceDefinition {
         }
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler() {
             super(ElytronDescriptionConstants.JDBC_REALM, ATTRIBUTES);

--- a/src/main/java/org/wildfly/extension/elytron/KeyStoreAliasDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/KeyStoreAliasDefinition.java
@@ -38,7 +38,6 @@ import java.security.cert.CertificateEncodingException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -196,7 +195,7 @@ class KeyStoreAliasDefinition extends SimpleResourceDefinition {
         return aliasName;
     }
 
-    abstract static class KeyStoreRuntimeOnlyHandler extends AbstractRuntimeOnlyHandler {
+    abstract static class KeyStoreRuntimeOnlyHandler extends ElytronRuntimeOnlyHandler {
 
         private final boolean serviceMustBeUp;
         private final boolean writeAccess;

--- a/src/main/java/org/wildfly/extension/elytron/KeyStoreDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/KeyStoreDefinition.java
@@ -42,7 +42,6 @@ import java.security.Provider;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -52,7 +51,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinition;
@@ -173,7 +171,7 @@ final class KeyStoreDefinition extends SimpleResourceDefinition {
             resourceRegistration.registerReadWriteAttribute(current, null, WRITE);
         }
 
-        resourceRegistration.registerReadOnlyAttribute(STATE, new AbstractRuntimeOnlyHandler() {
+        resourceRegistration.registerReadOnlyAttribute(STATE, new ElytronRuntimeOnlyHandler() {
 
             @Override
             protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
@@ -304,7 +302,7 @@ final class KeyStoreDefinition extends SimpleResourceDefinition {
 
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler() {
             super(ElytronDescriptionConstants.KEY_STORE, CONFIG_ATTRIBUTES);
@@ -320,7 +318,7 @@ final class KeyStoreDefinition extends SimpleResourceDefinition {
      * Runtime Attribute and Operation Handlers
      */
 
-    abstract static class KeyStoreRuntimeOnlyHandler extends AbstractRuntimeOnlyHandler {
+    abstract static class KeyStoreRuntimeOnlyHandler extends ElytronRuntimeOnlyHandler {
 
         private final boolean serviceMustBeUp;
         private final boolean writeAccess;

--- a/src/main/java/org/wildfly/extension/elytron/KeyStoreRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/KeyStoreRealmDefinition.java
@@ -33,7 +33,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -112,7 +111,7 @@ class KeyStoreRealmDefinition extends SimpleResourceDefinition {
 
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler() {
             super(ElytronDescriptionConstants.KEY_STORE_REALM, KEYSTORE);

--- a/src/main/java/org/wildfly/extension/elytron/LdapKeyStoreDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/LdapKeyStoreDefinition.java
@@ -37,7 +37,6 @@ import javax.naming.directory.BasicAttribute;
 import javax.naming.directory.BasicAttributes;
 import javax.naming.ldap.LdapName;
 
-import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectListAttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
@@ -47,7 +46,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -223,7 +221,7 @@ final class LdapKeyStoreDefinition extends SimpleResourceDefinition {
             resourceRegistration.registerReadWriteAttribute(current, null, WRITE);
         }
 
-        resourceRegistration.registerReadOnlyAttribute(STATE, new AbstractRuntimeOnlyHandler() {
+        resourceRegistration.registerReadOnlyAttribute(STATE, new ElytronRuntimeOnlyHandler() {
             @Override
             protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
                 ServiceName keyStoreName = LDAP_KEY_STORE_UTIL.serviceName(operation);
@@ -349,7 +347,7 @@ final class LdapKeyStoreDefinition extends SimpleResourceDefinition {
 
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler() {
             super(ElytronDescriptionConstants.LDAP_KEY_STORE, CONFIG_ATTRIBUTES);
@@ -380,7 +378,7 @@ final class LdapKeyStoreDefinition extends SimpleResourceDefinition {
                 .build();
     }
 
-    abstract static class LdapKeyStoreRuntimeOnlyHandler extends AbstractRuntimeOnlyHandler {
+    abstract static class LdapKeyStoreRuntimeOnlyHandler extends ElytronRuntimeOnlyHandler {
 
         private final boolean serviceMustBeUp;
         private final boolean writeAccess;

--- a/src/main/java/org/wildfly/extension/elytron/LdapRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/LdapRealmDefinition.java
@@ -47,7 +47,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -584,7 +583,7 @@ class LdapRealmDefinition extends SimpleResourceDefinition {
 
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler() {
             super(ElytronDescriptionConstants.LDAP_REALM, ATTRIBUTES);

--- a/src/main/java/org/wildfly/extension/elytron/PrincipalDecoderDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/PrincipalDecoderDefinitions.java
@@ -31,7 +31,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -277,7 +276,7 @@ class PrincipalDecoderDefinitions {
 
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler(String parentName, AttributeDefinition ... attributes) {
             super(parentName, attributes);

--- a/src/main/java/org/wildfly/extension/elytron/PropertiesRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/PropertiesRealmDefinition.java
@@ -38,7 +38,6 @@ import java.util.Date;
 import java.util.List;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
-import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -265,7 +264,7 @@ class PropertiesRealmDefinition extends TrivialResourceDefinition {
         });
     }
 
-    abstract static class PropertiesRuntimeHandler extends AbstractRuntimeOnlyHandler {
+    abstract static class PropertiesRuntimeHandler extends ElytronRuntimeOnlyHandler {
 
         private final boolean writeAccess;
 

--- a/src/main/java/org/wildfly/extension/elytron/ProviderDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/ProviderDefinitions.java
@@ -47,7 +47,6 @@ import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
-import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ListAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -272,7 +271,7 @@ class ProviderDefinitions {
         }
     }
 
-    private static class LoadedProvidersAttributeHandler extends AbstractRuntimeOnlyHandler {
+    private static class LoadedProvidersAttributeHandler extends ElytronRuntimeOnlyHandler {
 
         @Override
         protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {

--- a/src/main/java/org/wildfly/extension/elytron/RealmMapperDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/RealmMapperDefinitions.java
@@ -43,7 +43,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleMapAttributeDefinition;
@@ -277,7 +276,7 @@ class RealmMapperDefinitions {
 
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler(String parentName, AttributeDefinition ... attributes) {
             super(parentName, attributes);

--- a/src/main/java/org/wildfly/extension/elytron/RoleDecoderDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/RoleDecoderDefinitions.java
@@ -28,7 +28,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -107,7 +106,7 @@ class RoleDecoderDefinitions {
 
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler(String parentName, AttributeDefinition ... attributes) {
             super(parentName, attributes);

--- a/src/main/java/org/wildfly/extension/elytron/RoleMapperDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/RoleMapperDefinitions.java
@@ -34,7 +34,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -260,7 +259,7 @@ class RoleMapperDefinitions {
 
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler(String parentName, AttributeDefinition ... attributes) {
             super(parentName, attributes);

--- a/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -56,7 +56,6 @@ import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
-import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -674,7 +673,7 @@ class SSLDefinitions {
         throw ROOT_LOGGER.noTypeFound(X509ExtendedTrustManager.class.getSimpleName());
     }
 
-    abstract static class SSLContextRuntimeHandler extends AbstractRuntimeOnlyHandler {
+    abstract static class SSLContextRuntimeHandler extends ElytronRuntimeOnlyHandler {
         @Override
         protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
             ServiceName serviceName = getSSLContextServiceUtil().serviceName(operation);

--- a/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
+++ b/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
@@ -57,7 +57,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -489,7 +488,7 @@ class SaslServerDefinitions {
 
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler(String parentName, AttributeDefinition ... attributes) {
             super(parentName, attributes);

--- a/src/main/java/org/wildfly/extension/elytron/SecurityPropertyResourceDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/SecurityPropertyResourceDefinition.java
@@ -68,7 +68,7 @@ class SecurityPropertyResourceDefinition extends SimpleResourceDefinition {
     }
 
     private static SecurityPropertyService getService(OperationContext context) {
-        ServiceRegistry serviceRegistry = context.getServiceRegistry(false);
+        ServiceRegistry serviceRegistry = context.getServiceRegistry(true);
 
         ServiceController<?> service = serviceRegistry.getService(SecurityPropertyService.SERVICE_NAME);
         if (service != null) {

--- a/src/main/java/org/wildfly/extension/elytron/SecurityPropertyResourceDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/SecurityPropertyResourceDefinition.java
@@ -18,14 +18,11 @@
 
 package org.wildfly.extension.elytron;
 
-import org.jboss.as.controller.AbstractRemoveStepHandler;
-import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -93,7 +90,7 @@ class SecurityPropertyResourceDefinition extends SimpleResourceDefinition {
         getService(context).removeProperty(name);
     }
 
-    private static class WriteAttributeHandler extends AbstractWriteAttributeHandler<String> {
+    private static class WriteAttributeHandler extends ElytronWriteAttributeHandler<String> {
 
         private WriteAttributeHandler() {
             super(VALUE);
@@ -146,21 +143,10 @@ class SecurityPropertyResourceDefinition extends SimpleResourceDefinition {
 
     }
 
-    private static class PropertyRemoveHandler extends AbstractRemoveStepHandler {
+    private static class PropertyRemoveHandler extends ElytronRemoveStepHandler {
 
         private PropertyRemoveHandler() {
             super();
-        }
-
-        /**
-         * Ensures runtime operations are performed in the usual modes and also for an admin only server.
-         *
-         * @return Returns {@code true} in the existing situations and also for admin-only mode of a normal server.
-         * @see org.jboss.as.controller.AbstractAddStepHandler#requiresRuntime(org.jboss.as.controller.OperationContext)
-         */
-        @Override
-        protected boolean requiresRuntime(OperationContext context) {
-            return context.isDefaultRequiresRuntime() || context.isNormalServer() && RunningMode.ADMIN_ONLY == context.getRunningMode();
         }
 
         @Override

--- a/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
@@ -48,7 +48,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -302,7 +301,7 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
         }
     }
 
-    private static class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private static class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler() {
             super(ElytronDescriptionConstants.TOKEN_REALM, ATTRIBUTES);

--- a/src/main/java/org/wildfly/extension/elytron/TrivialCapabilityServiceRemoveHandler.java
+++ b/src/main/java/org/wildfly/extension/elytron/TrivialCapabilityServiceRemoveHandler.java
@@ -18,6 +18,7 @@
 package org.wildfly.extension.elytron;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.ServiceRemoveStepHandler;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -28,7 +29,7 @@ import org.jboss.msc.service.ServiceName;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-class TrivialCapabilityServiceRemoveHandler extends ServiceRemoveStepHandler {
+class TrivialCapabilityServiceRemoveHandler extends ServiceRemoveStepHandler implements ElytronOperationStepHandler {
 
     private final RuntimeCapability<?> firstCapability;
 
@@ -52,4 +53,8 @@ class TrivialCapabilityServiceRemoveHandler extends ServiceRemoveStepHandler {
         return firstCapability.fromBaseCapability(name).getCapabilityServiceName();
     }
 
+    @Override
+    protected boolean requiresRuntime(final OperationContext context) {
+        return isServerOrHostController(context);
+    }
 }

--- a/src/main/java/org/wildfly/extension/elytron/TrivialResourceDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/TrivialResourceDefinition.java
@@ -22,7 +22,6 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -69,7 +68,7 @@ class TrivialResourceDefinition extends SimpleResourceDefinition {
          }
     }
 
-    private class WriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    private class WriteAttributeHandler extends ElytronRestartParentWriteAttributeHandler {
 
         WriteAttributeHandler(String parentName, AttributeDefinition ... attributes) {
             super(parentName, attributes);

--- a/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
+++ b/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
@@ -22,6 +22,7 @@ package org.wildfly.extension.elytron;
 import java.io.IOException;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.junit.Before;
 import org.junit.Test;
 
 
@@ -37,6 +38,11 @@ public class SubsystemParsingTestCase extends AbstractSubsystemBaseTest {
 
     public SubsystemParsingTestCase() {
         super(ElytronExtension.SUBSYSTEM_NAME, new ElytronExtension());
+    }
+
+    @Before
+    public void init() throws Exception {
+        TestEnvironment.forceRequireRuntimeFalse();
     }
 
     @Override

--- a/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
+++ b/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
@@ -19,6 +19,7 @@ package org.wildfly.extension.elytron;
 
 import mockit.Mock;
 import mockit.MockUp;
+import org.jboss.as.controller.OperationContext;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.ControllerInitializer;
 
@@ -106,5 +107,25 @@ class TestEnvironment extends AdditionalInitialization {
 
     static void mockCallerModuleClassloader() {
         new ClassLoadingAttributeDefinitionsMock();
+    }
+
+    // base add handler mock to prevent services starting for parsing testcase
+    private static class BaseAddHandlerMock extends MockUp<BaseAddHandler> {
+        @Mock
+        protected boolean requiresRuntime(OperationContext context) {
+            return false;
+        }
+    }
+
+    static void forceRequireRuntimeFalse() throws Exception {
+        new BaseAddHandlerMock();
+
+        Class<?> innerClass = Class.forName(SecurityPropertyResourceDefinition.class.getName() + "$PropertyRemoveHandler");
+        new MockUp<Object>(innerClass) {
+            @Mock
+            protected boolean requiresRuntime(OperationContext context) {
+                return false;
+            }
+        };
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8062
https://issues.jboss.org/browse/WFLY-8063

I've added a few new `OperationStepHandler`'s. These were added in a attempt to cut down on where the `requiresRuntime()` would be needed. They all start with the `Elytron` prefix which can be changed to something better.

I've tested this on WildFly in both standalone and domain as well as normal and admin-only modes with a set of simple commands to add a new realm and security domain.