### PR TITLE
[WFLY-8104] Coverity static analysis, Dereference after null check, KeyStoreService (elytron-subsystem)

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/KeyStoreService.java
+++ b/src/main/java/org/wildfly/extension/elytron/KeyStoreService.java
@@ -267,11 +267,13 @@ class KeyStoreService implements ModifiableKeyStoreService {
     private char[] resolvePassword() throws Exception {
         ExceptionSupplier<CredentialSource, Exception> sourceSupplier = credentialSourceSupplier.getValue();
         CredentialSource cs = sourceSupplier != null ? sourceSupplier.get() : null;
-        if (cs != null) {
-            return cs.getCredential(PasswordCredential.class).getPassword(ClearPassword.class).getPassword();
-        } else {
-            throw ROOT_LOGGER.keyStorePasswordCannotBeResolved(resolvedPath.getPath());
-        }
+        if (cs == null) throw ROOT_LOGGER.keyStorePasswordCannotBeResolved(resolvedPath.getPath());
+        PasswordCredential credential = cs.getCredential(PasswordCredential.class);
+        if (credential == null) throw ROOT_LOGGER.keyStorePasswordCannotBeResolved(resolvedPath.getPath());
+        ClearPassword password = credential.getPassword(ClearPassword.class);
+        if (password == null) throw ROOT_LOGGER.keyStorePasswordCannotBeResolved(resolvedPath.getPath());
+
+        return password.getPassword();
     }
 
     static class LoadKey {


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-8104
