### PR TITLE
[WFLY-8103] Coverity static analysis, Dereference after null check, KeyStoreService (elytron-subsystem)

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/KeyStoreService.java
+++ b/src/main/java/org/wildfly/extension/elytron/KeyStoreService.java
@@ -267,11 +267,12 @@ class KeyStoreService implements ModifiableKeyStoreService {
     private char[] resolvePassword() throws Exception {
         ExceptionSupplier<CredentialSource, Exception> sourceSupplier = credentialSourceSupplier.getValue();
         CredentialSource cs = sourceSupplier != null ? sourceSupplier.get() : null;
-        if (cs == null) throw ROOT_LOGGER.keyStorePasswordCannotBeResolved(resolvedPath.getPath());
+        String path = resolvedPath != null ? resolvedPath.getPath() : "null";
+        if (cs == null) throw ROOT_LOGGER.keyStorePasswordCannotBeResolved(path);
         PasswordCredential credential = cs.getCredential(PasswordCredential.class);
-        if (credential == null) throw ROOT_LOGGER.keyStorePasswordCannotBeResolved(resolvedPath.getPath());
+        if (credential == null) throw ROOT_LOGGER.keyStorePasswordCannotBeResolved(path);
         ClearPassword password = credential.getPassword(ClearPassword.class);
-        if (password == null) throw ROOT_LOGGER.keyStorePasswordCannotBeResolved(resolvedPath.getPath());
+        if (password == null) throw ROOT_LOGGER.keyStorePasswordCannotBeResolved(path);
 
         return password.getPassword();
     }


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-8103