### PR TITLE
Resolves #432 : adding elytron extension to wildfly-core causes server boot failure

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -280,6 +280,10 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 32, value = "Unable to reload CRL file.")
     RuntimeException unableToReloadCRL(@Cause Exception cause);
 
+    @LogMessage(level = WARN)
+    @Message(id = 33, value = "Module \"%s\" is not present. Resource not loaded (\"%s\").")
+    void moduleNotPresentCannotLoadResource(String module, String resource);
+
     // CREDENTIAL_STORE section
     @Message(id = 909, value = "Credential store '%s' does not support given credential store entry type '%s'")
     IllegalArgumentException credentialStoreEntryTypeNotSupported(String credentialStoreName, String entryType);

--- a/src/main/resources/module/main/module.xml
+++ b/src/main/resources/module/main/module.xml
@@ -29,7 +29,7 @@
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="javax.security.jacc.api"/>
+        <module name="javax.security.jacc.api" optional="true"/>
         <module name="sun.jdk"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.staxmapper"/>
@@ -42,6 +42,6 @@
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron"/>
         <!-- Temporary due to backward compatibility with the configuration of JACC and related services -->
-        <module name="org.picketbox"/>
+        <module name="org.picketbox" optional="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Issue #432 
I think we should be able to add Elytron extension to WildFly Core and JACC is not relevant there.
I just disabled registering of jacc-policy in case there is missing javax.security.jacc.api module and made missing modules optional.