### PR TITLE
[WFLY-8235] Wrong type of Elytron match-no-user in XSD

### DIFF
--- a/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -284,7 +284,7 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-                    <xs:attribute name="match-no-user" type="xs:string" default="false">
+                    <xs:attribute name="match-no-user" type="xs:boolean" default="false">
                         <xs:annotation>
                             <xs:documentation>
                                 Match based on no user.


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFLY-8235
