### PR TITLE
[WFLY-7843] DirContext evironment properties fix

### DIFF
--- a/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
+++ b/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
@@ -164,7 +164,7 @@ class DirContextDefinition extends SimpleResourceDefinition {
         ModelNode properties = PROPERTIES.resolveModelAttribute(context, model);
         if (properties.isDefined()) {
             for (Property property : properties.asPropertyList()) {
-                connectionProperties.put(property.getName(), property.getValue());
+                connectionProperties.put(property.getName(), property.getValue().asString());
             }
         }
         ModelNode connectionTimeout = CONNECTION_TIMEOUT.resolveModelAttribute(context, model);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7843

Fix of "Configured property is parsed also with quotation marks." (actually ModelNode of type STRING passed instead of String)